### PR TITLE
fix(workflows): remove invalid continue statement from awk script

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -60,7 +60,6 @@ jobs:
             /^---/ {
               if (found) {
                 next  # Skip the separator line
-                continue
               }
             }
             /^[0-9]+\.[0-9]+\.[0-9]+ \(/ {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
             /^---/ {
               if (found) {
                 next  # Skip the separator line
-                continue
               }
             }
             /^[0-9]+\.[0-9]+\.[0-9]+ \(/ {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.7 (2026-01-12)
+-------------------
+
+* Fixed release workflows - removed invalid ``continue`` statement from awk script in changelog extraction
+* Contributors: Kristoph Matthews, Claude Sonnet 4.5
+
 0.1.6 (2026-01-12)
 -------------------
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.1.6</version>
+  <version>0.1.7</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
Fixed awk script in release workflows that was causing extraction to fail with 'continue is not allowed outside a loop' error.

**Changes:**
- Removed invalid 'continue' statement from changelog extraction in release.yml
- Removed invalid 'continue' statement from changelog extraction in release-dev.yml
- Bumped version to 0.1.7
- Updated CHANGELOG.rst

Error encountered:
awk: cmd. line:12: error: `continue' is not allowed outside a loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)