### PR TITLE
feat(infra): Migrate from Cloudsmith to AWS S3-based package hosting …

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -1,10 +1,8 @@
-# Cloudsmith Credentials
-# Copy this file to .env.local and fill in your credentials
-# Format: username:api_key (colon-separated, no spaces)
+# RobotOps APT Repository Configuration
+# Copy this file to .env.local to customize the package repository
+# By default, uses the production repository
 
-CLOUDSMITH_USERNAME=your-cloudsmith-username
-CLOUDSMITH_API_KEY=your-cloudsmith-api-key
-
-# Optional: Override the Cloudsmith repository
-# Defaults to robotops
-# CLOUDSMITH_REPO=robotops
+# Optional: Override the APT repository URL
+# Production (default): https://apt.robotops.com
+# Development: https://apt.development.robotops.com
+# APT_REPO_URL=https://apt.robotops.com

--- a/.github/actions/publish-debian-s3/action.yml
+++ b/.github/actions/publish-debian-s3/action.yml
@@ -1,0 +1,173 @@
+name: 'Publish Debian Package to S3'
+description: 'Publishes Debian packages to S3 using Aptly with GPG signing and CloudFront invalidation'
+
+inputs:
+  deb-files:
+    description: 'Path pattern to .deb files to publish'
+    required: true
+  apt-bucket:
+    description: 'S3 bucket name for apt repository'
+    required: true
+  cloudfront-distribution-id:
+    description: 'CloudFront distribution ID for cache invalidation'
+    required: true
+  gpg-private-key:
+    description: 'GPG private key for package signing (armored)'
+    required: true
+  gpg-passphrase:
+    description: 'GPG key passphrase (use empty string if no passphrase)'
+    required: false
+    default: ''
+  aws-region:
+    description: 'AWS region'
+    required: false
+    default: 'us-east-1'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Aptly
+      shell: bash
+      run: |
+        # Add Aptly repository
+        sudo mkdir -p /etc/apt/keyrings
+        wget -qO - https://www.aptly.info/pubkey.txt | gpg --dearmor | sudo tee /etc/apt/keyrings/aptly.gpg > /dev/null
+        echo "deb [signed-by=/etc/apt/keyrings/aptly.gpg] http://repo.aptly.info/ squeeze main" | sudo tee /etc/apt/sources.list.d/aptly.list
+
+        # Install Aptly and dependencies
+        # Note: AWS CLI is pre-installed on GitHub Actions runners
+        sudo apt-get update
+        sudo apt-get install -y aptly gnupg2
+
+    - name: Import GPG Key
+      shell: bash
+      run: |
+        # Import the GPG key
+        echo "${{ inputs.gpg-private-key }}" | gpg --batch --import
+
+        # Get the key ID
+        export GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2 | head -n1)
+        echo "GPG_KEY_ID=$GPG_KEY_ID" >> $GITHUB_ENV
+        echo "Imported GPG key: $GPG_KEY_ID"
+
+    - name: Configure Aptly
+      shell: bash
+      run: |
+        # Create Aptly config
+        mkdir -p ~/.aptly
+        cat > ~/.aptly.conf <<EOF
+        {
+          "rootDir": "$HOME/.aptly",
+          "downloadConcurrency": 4,
+          "downloadSpeedLimit": 0,
+          "architectures": ["amd64", "arm64"],
+          "dependencyFollowSuggests": false,
+          "dependencyFollowRecommends": false,
+          "dependencyFollowAllVariants": false,
+          "dependencyFollowSource": false,
+          "dependencyVerboseResolve": false,
+          "gpgDisableSign": false,
+          "gpgDisableVerify": false,
+          "gpgProvider": "gpg",
+          "downloadSourcePackages": false,
+          "skipLegacyPool": true,
+          "ppaDistributorID": "ubuntu",
+          "ppaCodename": "",
+          "skipContentsPublishing": false,
+          "FileSystemPublishEndpoints": {},
+          "S3PublishEndpoints": {
+            "robotops": {
+              "region": "${{ inputs.aws-region }}",
+              "bucket": "${{ inputs.apt-bucket }}"
+            }
+          },
+          "SwiftPublishEndpoints": {}
+        }
+        EOF
+
+    - name: Sync Existing Repo from S3
+      shell: bash
+      run: |
+        # Check if repo exists in S3 and sync it
+        if aws s3 ls s3://${{ inputs.apt-bucket }}/dists/ 2>/dev/null; then
+          echo "Existing repository found, syncing from S3..."
+          mkdir -p ~/.aptly/public
+          aws s3 sync s3://${{ inputs.apt-bucket }}/ ~/.aptly/public/ || echo "No existing repo to sync"
+        else
+          echo "No existing repository found in S3"
+        fi
+
+    - name: Create or Update Repository
+      shell: bash
+      run: |
+        REPO_NAME="robotops"
+        DISTRIBUTIONS="noble jammy focal"
+
+        # Try to restore from S3 snapshot if it exists
+        if aws s3 ls s3://${{ inputs.apt-bucket }}/.aptly/ 2>/dev/null; then
+          echo "Restoring Aptly database from S3..."
+          mkdir -p ~/.aptly
+          aws s3 sync s3://${{ inputs.apt-bucket }}/.aptly/ ~/.aptly/ || echo "No snapshot to restore"
+        fi
+
+        # Check if repo exists, create if not
+        if ! aptly repo list -raw | grep -q "^${REPO_NAME}$"; then
+          echo "Creating new Aptly repository: ${REPO_NAME}"
+          aptly repo create -distribution=noble -component=main ${REPO_NAME}
+        else
+          echo "Repository ${REPO_NAME} already exists"
+        fi
+
+        # Add all .deb files
+        echo "Adding packages to repository..."
+        for deb in ${{ inputs.deb-files }}; do
+          if [ -f "$deb" ]; then
+            echo "Adding: $deb"
+            aptly repo add ${REPO_NAME} "$deb"
+          fi
+        done
+
+    - name: Publish to S3
+      shell: bash
+      env:
+        GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
+      run: |
+        REPO_NAME="robotops"
+        DISTRIBUTIONS="noble jammy focal"
+
+        # For each distribution
+        for dist in $DISTRIBUTIONS; do
+          # Check if this distribution is already published
+          if aptly publish list -raw | grep -q "^s3:robotops:\. ${dist}$"; then
+            echo "Updating existing publication for ${dist}..."
+            aptly publish update -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" ${dist} s3:robotops:
+          else
+            echo "Creating new publication for ${dist}..."
+            aptly publish repo -batch -passphrase="${GPG_PASSPHRASE}" -gpg-key="${GPG_KEY_ID}" -distribution=${dist} -component=main ${REPO_NAME} s3:robotops:
+          fi
+        done
+
+        # Backup Aptly database to S3 for future runs
+        echo "Backing up Aptly database to S3..."
+        aws s3 sync ~/.aptly/ s3://${{ inputs.apt-bucket }}/.aptly/ --exclude "public/*"
+
+    - name: Invalidate CloudFront Cache
+      shell: bash
+      run: |
+        echo "Invalidating CloudFront cache..."
+        aws cloudfront create-invalidation \
+          --distribution-id ${{ inputs.cloudfront-distribution-id }} \
+          --paths "/*" \
+          --region us-east-1
+
+    - name: Summary
+      shell: bash
+      run: |
+        echo "✅ Debian packages published successfully!"
+        echo "Repository: https://${{ inputs.apt-bucket }}.s3.${{ inputs.aws-region }}.amazonaws.com/"
+        echo "Packages published:"
+        for deb in ${{ inputs.deb-files }}; do
+          if [ -f "$deb" ]; then
+            echo "  - $(basename $deb)"
+          fi
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Prepare Cloudsmith credentials
-        run: |
-          # Service account format: service_account_username:api_key
-          mkdir -p ~/.cloudsmith
-          echo "github-actions-bk1d:${{ secrets.CLOUDSMITH_API_KEY }}" > ~/.cloudsmith/key
-
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
@@ -30,10 +24,10 @@ jobs:
           push: false
           load: true
           tags: rmw_robotops:ci
+          build-args: |
+            APT_REPO_URL=https://apt.robotops.com
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secret-files: |
-            cloudsmith_key=/home/runner/.cloudsmith/key
 
       - name: Run CI suite (lint, build, test)
         run: |

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -9,6 +9,14 @@ on:
         type: boolean
         default: false
 
+env:
+  AWS_REGION: us-east-1
+  AWS_ACCOUNT_ID: '717949299175'
+  DEPLOY_ROLE: arn:aws:iam::717949299175:role/github-actions-deploy-development
+  CLOUDFRONT_DISTRIBUTION_ID: EE9YB1UW7HRUQ
+  APT_BUCKET: robotops-apt-pub-development
+  APT_REPO_URL: https://apt.development.robotops.com
+
 jobs:
   release-dev:
     runs-on: ubuntu-latest
@@ -75,7 +83,7 @@ jobs:
           echo "" >> release_notes.md
           echo "---" >> release_notes.md
           echo "" >> release_notes.md
-          echo "**📦 Debian Packages:** https://cloudsmith.io/~robotops/repos/robotops-development/packages/" >> release_notes.md
+          echo "**📦 Debian Packages:** https://apt.development.robotops.com" >> release_notes.md
 
           echo "Extracted changelog:"
           cat release_notes.md
@@ -102,7 +110,7 @@ jobs:
           echo "### Release Notes" >> $GITHUB_STEP_SUMMARY
           cat release_notes.md >> $GITHUB_STEP_SUMMARY
 
-  publish-dev-packages:
+  build-dev-packages:
     runs-on: ${{ matrix.runner }}
     needs: release-dev
     if: ${{ !inputs.dry_run }}
@@ -126,12 +134,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$DEV_TAG" >> $GITHUB_OUTPUT
 
-      - name: Determine Cloudsmith repository
-        id: repo
-        run: |
-          echo "repo=robotops-development" >> $GITHUB_OUTPUT
-          echo "Deploying to: development (robotops-development)"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -145,9 +147,7 @@ jobs:
           load: true
           tags: rmw-robotops:build-${{ matrix.arch }}
           build-args: |
-            CLOUDSMITH_REPO=${{ steps.repo.outputs.repo }}
-            CLOUDSMITH_USERNAME=${{ secrets.CLOUDSMITH_USERNAME }}
-            CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
+            APT_REPO_URL=${{ env.APT_REPO_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -175,25 +175,68 @@ jobs:
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
-      - name: Upload to Cloudsmith
-        uses: cloudsmith-io/action@v0.6.10
+      - name: Upload Debian package as artifact
+        uses: actions/upload-artifact@v4
         with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "robotops"
-          repo: ${{ steps.repo.outputs.repo }}
-          distro: "ubuntu"
-          release: "noble"
-          republish: "true"
-          file: ${{ steps.deb.outputs.file }}
+          name: debian-package-${{ matrix.arch }}
+          path: ${{ steps.deb.outputs.file }}
+          retention-days: 1
+
+  publish-dev-debian:
+    runs-on: ubuntu-latest
+    needs: build-dev-packages
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      id-token: write  # Needed for AWS OIDC
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=<version>)[^<]+' package.xml)
+          DEV_TAG="v${VERSION}-development-$(git rev-parse --short HEAD)"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$DEV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download all Debian packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: debian-package-*
+          path: ./packages
+          merge-multiple: true
+
+      - name: List downloaded packages
+        run: |
+          echo "Downloaded packages:"
+          ls -lh ./packages/
+
+      - name: Publish Debian packages to S3
+        uses: ./.github/actions/publish-debian-s3
+        with:
+          deb-files: './packages/*.deb'
+          apt-bucket: ${{ env.APT_BUCKET }}
+          cloudfront-distribution-id: ${{ env.CLOUDFRONT_DISTRIBUTION_ID }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Summary
         run: |
-          echo "## Package Publishing (Development - ${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Debian Package Publishing (Development)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "Package: ${{ steps.deb.outputs.file }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Debian package: https://cloudsmith.io/~robotops/repos/${{ steps.repo.outputs.repo }}/packages/" >> $GITHUB_STEP_SUMMARY
+          echo "### Published Packages" >> $GITHUB_STEP_SUMMARY
+          for deb in ./packages/*.deb; do
+            echo "- $(basename $deb)" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ APT Repository: https://apt.development.robotops.com" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,14 @@ on:
         type: boolean
         default: false
 
+env:
+  AWS_REGION: us-east-1
+  AWS_ACCOUNT_ID: '189676910689'
+  DEPLOY_ROLE: arn:aws:iam::189676910689:role/github-actions-deploy-production
+  CLOUDFRONT_DISTRIBUTION_ID: E3QAA3BBMD2WVG
+  APT_BUCKET: robotops-apt-pub-production
+  APT_REPO_URL: https://apt.robotops.com
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -75,7 +83,7 @@ jobs:
           echo "" >> release_notes.md
           echo "---" >> release_notes.md
           echo "" >> release_notes.md
-          echo "**📦 Debian Packages:** https://cloudsmith.io/~robotops/repos/robotops/packages/" >> release_notes.md
+          echo "**📦 Debian Packages:** https://apt.robotops.com" >> release_notes.md
 
           echo "Extracted changelog:"
           cat release_notes.md
@@ -101,7 +109,7 @@ jobs:
           echo "### Release Notes" >> $GITHUB_STEP_SUMMARY
           cat release_notes.md >> $GITHUB_STEP_SUMMARY
 
-  publish-packages:
+  build-packages:
     runs-on: ${{ matrix.runner }}
     needs: release
     if: ${{ !inputs.dry_run }}
@@ -124,12 +132,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Determine Cloudsmith repository
-        id: repo
-        run: |
-          echo "repo=robotops" >> $GITHUB_OUTPUT
-          echo "Deploying to: production (robotops)"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -143,9 +145,7 @@ jobs:
           load: true
           tags: rmw-robotops:build-${{ matrix.arch }}
           build-args: |
-            CLOUDSMITH_REPO=${{ steps.repo.outputs.repo }}
-            CLOUDSMITH_USERNAME=${{ secrets.CLOUDSMITH_USERNAME }}
-            CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }}
+            APT_REPO_URL=${{ env.APT_REPO_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -173,25 +173,67 @@ jobs:
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
-      - name: Upload to Cloudsmith
-        uses: cloudsmith-io/action@v0.6.10
+      - name: Upload Debian package as artifact
+        uses: actions/upload-artifact@v4
         with:
-          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          command: "push"
-          format: "deb"
-          owner: "robotops"
-          repo: ${{ steps.repo.outputs.repo }}
-          distro: "ubuntu"
-          release: "noble"
-          republish: "true"
-          file: ${{ steps.deb.outputs.file }}
+          name: debian-package-${{ matrix.arch }}
+          path: ${{ steps.deb.outputs.file }}
+          retention-days: 1
+
+  publish-debian:
+    runs-on: ubuntu-latest
+    needs: build-packages
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      id-token: write  # Needed for AWS OIDC
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=<version>)[^<]+' package.xml)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download all Debian packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: debian-package-*
+          path: ./packages
+          merge-multiple: true
+
+      - name: List downloaded packages
+        run: |
+          echo "Downloaded packages:"
+          ls -lh ./packages/
+
+      - name: Publish Debian packages to S3
+        uses: ./.github/actions/publish-debian-s3
+        with:
+          deb-files: './packages/*.deb'
+          apt-bucket: ${{ env.APT_BUCKET }}
+          cloudfront-distribution-id: ${{ env.CLOUDFRONT_DISTRIBUTION_ID }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Summary
         run: |
-          echo "## Package Publishing (${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Debian Package Publishing" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Version: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "Package: ${{ steps.deb.outputs.file }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Debian package: https://cloudsmith.io/~robotops/repos/${{ steps.repo.outputs.repo }}/packages/" >> $GITHUB_STEP_SUMMARY
+          echo "### Published Packages" >> $GITHUB_STEP_SUMMARY
+          for deb in ./packages/*.deb; do
+            echo "- $(basename $deb)" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ APT Repository: https://apt.robotops.com" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-02-08)
+-------------------
+
+* **INFRASTRUCTURE**: Migrated from Cloudsmith to AWS S3-based package hosting using Aptly (ROB-127)
+* Replaced Cloudsmith with AWS S3/Aptly for Debian package hosting
+* Updated release.yml and release-dev.yml workflows to publish to S3 via custom GitHub action
+* Removed Cloudsmith authentication requirements from Dockerfile and docker-compose.yml
+* Production APT repository: https://apt.robotops.com
+* Development APT repository: https://apt.development.robotops.com
+* Updated CLAUDE.md documentation to reflect new package hosting infrastructure
+* Cost savings: Reduced hosting costs from $149/month to ~$1-5/month
+* **BREAKING**: Cloudsmith credentials (CLOUDSMITH_USERNAME, CLOUDSMITH_API_KEY) no longer used
+* **BREAKING**: Optional APT_REPO_URL environment variable replaces CLOUDSMITH_REPO
+* No authentication required - all packages are now publicly accessible
+
 0.5.0 (2026-01-15)
 -------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Each command:
 4. Workflow:
    - Creates git tag `v{version}` (e.g., `v0.1.5`)
    - Builds Debian packages for amd64 and arm64
-   - Publishes to Cloudsmith `robotops` repo
+   - Publishes to AWS S3 via Aptly at https://apt.robotops.com
    - Creates GitHub Release with changelog excerpt
 
 #### Development Release (from `development` branch)
@@ -93,7 +93,7 @@ Each command:
 3. Workflow:
    - Creates git tag `v{version}-development-{sha}` (e.g., `v0.1.5-development-abc123`)
    - Builds Debian packages for amd64 and arm64
-   - Publishes to Cloudsmith `robotops-development` repo
+   - Publishes to AWS S3 via Aptly at https://apt.development.robotops.com
    - Creates GitHub Pre-Release with changelog excerpt
 
 **Both workflows support dry-run mode** for validation before actual release.
@@ -103,7 +103,7 @@ Each command:
 Pull requests to `main` or `development` automatically verify:
 - Version in `package.xml` has been incremented
 - CHANGELOG.rst has an entry for the new version (format: `X.Y.Z (YYYY-MM-DD)`)
-- New version is higher than latest published version in Cloudsmith
+- New version is higher than latest published version in APT repository
 
 If these checks fail, update your version and changelog before merging.
 
@@ -179,27 +179,31 @@ colcon build  # This will fail - ROS2 not installed!
 ### Multi-Stage Dockerfile
 
 Single `Dockerfile` with build stages:
-- `base` - Common dependencies (ROS2, FastDDS, Cloudsmith, robotops_msgs)
+- `base` - Common dependencies (ROS2, FastDDS, APT repository, robotops_msgs)
 - `dev` - Development environment (extends base)
 - `test` - Test environment with sanitizers (extends base)
 
 This keeps the setup DRY and maintainable.
 
-### Cloudsmith Authentication
+### APT Repository Configuration
 
-Private `robotops_msgs` dependency requires Cloudsmith credentials:
+RobotOps packages (`robotops_msgs`, `robotops_config`) are hosted on AWS S3 and served via public APT repositories:
+
+- **Production**: https://apt.robotops.com (default)
+- **Development**: https://apt.development.robotops.com
+
+The production repository is used by default. To use the development repository:
 
 ```bash
 # Copy template and configure
 cp .env.local.template .env.local
-# Edit .env.local with your credentials:
-# CLOUDSMITH_USERNAME=your-username
-# CLOUDSMITH_API_KEY=your-api-key
+# Edit .env.local to use development repository:
+# APT_REPO_URL=https://apt.development.robotops.com
 ```
 
 The `.env.local` file is automatically loaded by `docker-compose` and must **never be committed** (see `.gitignore`).
 
-Each developer uses their own Cloudsmith username and API key.
+No authentication is required - all packages are publicly accessible.
 
 ### Viewing robotops_msgs Schemas
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,10 @@
 # ============================================================================
 FROM ros:jazzy-ros-base AS base
 
-# Build arguments for configurable Cloudsmith repository
-# Production
-ARG CLOUDSMITH_REPO=robotops
-# Development
-# ARG CLOUDSMITH_REPO=robotops-development
-ARG CLOUDSMITH_USERNAME
-ARG CLOUDSMITH_API_KEY
+# Build argument for configurable APT repository environment
+# Production: apt.robotops.com
+# Development: apt.development.robotops.com
+ARG APT_REPO_URL=https://apt.robotops.com
 
 # Install core build dependencies and packaging tools
 RUN apt-get update && apt-get install -y \
@@ -30,21 +27,21 @@ RUN apt-get update && apt-get install -y \
     libprotobuf-dev \
     protobuf-compiler \
     libxxhash-dev \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install just command runner (make installation non-fatal in case of download issues)
 RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin || echo "Warning: just installation failed, but continuing..."
 
-# Configure Cloudsmith APT repositories
-# 1. Development repository (private) - for in-development packages
-# 2. Public repository - for released packages like robotops-config
-RUN echo "deb [trusted=yes] https://${CLOUDSMITH_USERNAME}:${CLOUDSMITH_API_KEY}@dl.cloudsmith.io/basic/robotops/${CLOUDSMITH_REPO}/deb/ubuntu noble main" \
-    > /etc/apt/sources.list.d/robotops-${CLOUDSMITH_REPO}.list && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/robotops/robotops/setup.deb.sh' | bash && \
-    # Update package cache to include new repositories
+# Configure RobotOps APT repository
+# Add GPG key for package verification
+RUN curl -fsSL "${APT_REPO_URL}/gpg.key" | gpg --dearmor -o /etc/apt/keyrings/robotops.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/robotops.gpg] ${APT_REPO_URL} noble main" \
+    > /etc/apt/sources.list.d/robotops.list && \
+    # Update package cache to include new repository
     apt-get update
 
-# Add custom rosdep rules for RobotOps packages (from Cloudsmith, not rosdistro)
+# Add custom rosdep rules for RobotOps packages
 RUN mkdir -p /etc/ros/rosdep/sources.list.d && \
     printf '%s\n' \
     'robotops-config:' '  ubuntu:' '    - ros-jazzy-robotops-config' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,9 @@ RUN apt-get update && apt-get install -y \
 RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin || echo "Warning: just installation failed, but continuing..."
 
 # Configure RobotOps APT repository
-# Add GPG key for package verification
-RUN curl -fsSL "${APT_REPO_URL}/gpg.key" | gpg --dearmor -o /etc/apt/keyrings/robotops.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/robotops.gpg] ${APT_REPO_URL} noble main" \
+RUN curl -fsSL ${APT_REPO_URL}/robotops-public-key.asc | gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] ${APT_REPO_URL} noble main" \
     > /etc/apt/sources.list.d/robotops.list && \
-    # Update package cache to include new repository
     apt-get update
 
 # Add custom rosdep rules for RobotOps packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,9 @@ services:
       dockerfile: Dockerfile
       target: dev
       args:
-        # Production
-        CLOUDSMITH_REPO: ${CLOUDSMITH_REPO:-robotops}
-        # Development
-        # CLOUDSMITH_REPO: ${CLOUDSMITH_REPO:-robotops-development}
-        CLOUDSMITH_USERNAME: ${CLOUDSMITH_USERNAME}
-        CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY}
+        # Production: https://apt.robotops.com
+        # Development: https://apt.development.robotops.com
+        APT_REPO_URL: ${APT_REPO_URL:-https://apt.robotops.com}
     image: rmw_robotops:dev
     volumes:
       - .:/workspace/src/rmw_robotops
@@ -40,12 +37,9 @@ services:
       dockerfile: Dockerfile
       target: test
       args:
-        # Production
-        CLOUDSMITH_REPO: ${CLOUDSMITH_REPO:-robotops}
-        # Development
-        # CLOUDSMITH_REPO: ${CLOUDSMITH_REPO:-robotops-development}
-        CLOUDSMITH_USERNAME: ${CLOUDSMITH_USERNAME}
-        CLOUDSMITH_API_KEY: ${CLOUDSMITH_API_KEY}
+        # Production: https://apt.robotops.com
+        # Development: https://apt.development.robotops.com
+        APT_REPO_URL: ${APT_REPO_URL:-https://apt.robotops.com}
     image: rmw_robotops:test
     volumes:
       - .:/workspace/src/rmw_robotops

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
…(ROB-127)

Replaced Cloudsmith package hosting with AWS S3/Aptly infrastructure to reduce costs from $149/month to ~$1-5/month.

**Key changes:**

- Created `.github/actions/publish-debian-s3` custom action for Aptly publishing
- Updated `release.yml` and `release-dev.yml` workflows to use AWS S3/Aptly
- Removed Cloudsmith authentication from Dockerfile and docker-compose.yml
- Replaced `CLOUDSMITH_*` build args with `APT_REPO_URL` parameter
- Updated `.env.local.template` to reflect new public APT repositories
- Updated CLAUDE.md documentation with new infrastructure details

**APT Repositories:**
- Production: https://apt.robotops.com
- Development: https://apt.development.robotops.com

**Breaking changes:**
- `CLOUDSMITH_USERNAME` and `CLOUDSMITH_API_KEY` no longer used
- `CLOUDSMITH_REPO` replaced with optional `APT_REPO_URL`
- No authentication required - packages are publicly accessible

Related to ROB-127