### PR TITLE
feat(tracing): implement TraceContextChange publisher for log-to-trac…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.0 (2026-04-03)
+-------------------
+
+* **NEW FEATURE**: Implement TraceContextChange publisher for end-to-end log-to-trace correlation (ROB-179)
+* Added ``TraceContextChangePublisher``: background thread publishing to ``/robotops/trace_context`` with 512-slot MPSC ring buffer, best-effort QoS, following existing ``trace_publisher.cpp`` pattern
+* Emit ``CONTEXT_ENTERED`` in ``rmw_take_with_info``, ``rmw_take_request``, ``rmw_take_response`` when thread-local trace context is set after receiving a message
+* Emit ``CONTEXT_EXITED`` in ``rmw_publish`` and ``rmw_send_response`` when the downstream operation completes
+* Fills the gap between ROB-94 (robot_agent subscriber) and ROB-55 (rmw_robotops trace events): ``robot_agent`` can now correlate ``/rosout`` logs with active trace spans
+* Added ``get_current_thread_id()`` utility to ``utils.hpp`` for multi-threaded executor support
+
 0.6.0 (2026-02-08)
 -------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(${PROJECT_NAME} SHARED
   src/trace_context.cpp
   src/trace_event_queue.cpp
   src/trace_publisher.cpp
+  src/trace_context_change_publisher.cpp
   src/diagnostics_metrics.cpp
   src/diagnostics_publisher.cpp
   src/span_id_generator.cpp

--- a/include/rmw_robotops/trace_context_change_publisher.hpp
+++ b/include/rmw_robotops/trace_context_change_publisher.hpp
@@ -1,0 +1,68 @@
+// Copyright 2025 Robot Ops Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_ROBOTOPS__TRACE_CONTEXT_CHANGE_PUBLISHER_HPP_
+#define RMW_ROBOTOPS__TRACE_CONTEXT_CHANGE_PUBLISHER_HPP_
+
+#include <cstdint>
+#include "rmw/rmw.h"
+#include "rmw_robotops/trace_context.hpp"
+
+namespace rmw_robotops
+{
+
+/// Maximum length for node name / namespace strings in context change events
+/// Matches MAX_NODE_NAME_LENGTH from trace_event_queue.hpp
+constexpr size_t MAX_CTX_NODE_NAME_LENGTH = 256;
+
+/// Context change type constants (match robotops_msgs::msg::TraceContextChange)
+constexpr uint8_t CONTEXT_CHANGE_ENTERED = 1;  // Callback started with trace context
+constexpr uint8_t CONTEXT_CHANGE_EXITED = 2;   // Callback completed, context cleared
+
+/// Fixed-size event struct for trace context changes
+/// No heap allocation: safe to enqueue on the robot's hot path
+struct TraceContextChangeEvent
+{
+  uint64_t timestamp_ns;
+  char node_name[MAX_CTX_NODE_NAME_LENGTH];
+  char node_namespace[MAX_CTX_NODE_NAME_LENGTH];
+  uint64_t thread_id;
+  char trace_id[TRACE_ID_LENGTH + 1];
+  char span_id[SPAN_ID_LENGTH + 1];
+  uint8_t change_type;  // 1=CONTEXT_ENTERED, 2=CONTEXT_EXITED
+
+  TraceContextChangeEvent() noexcept
+  : timestamp_ns(0), thread_id(0), change_type(0)
+  {
+    node_name[0] = '\0';
+    node_namespace[0] = '\0';
+    trace_id[0] = '\0';
+    span_id[0] = '\0';
+  }
+};
+
+/// Enqueue a trace context change event (non-blocking, noexcept)
+/// Returns false if the queue is full — caller should record the drop but not fail
+bool enqueue_context_change(const TraceContextChangeEvent & event) noexcept;
+
+/// Start the background thread that drains the context change queue and publishes
+/// to /robotops/trace_context.  Non-fatal: if this fails the robot continues normally.
+rmw_ret_t start_trace_context_change_publisher(rmw_context_t * context) noexcept;
+
+/// Stop the background publisher thread.  Idempotent and safe to call multiple times.
+rmw_ret_t stop_trace_context_change_publisher() noexcept;
+
+}  // namespace rmw_robotops
+
+#endif  // RMW_ROBOTOPS__TRACE_CONTEXT_CHANGE_PUBLISHER_HPP_

--- a/include/rmw_robotops/utils.hpp
+++ b/include/rmw_robotops/utils.hpp
@@ -17,7 +17,9 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <string>
+#include <thread>
 
 // Forward declaration for introspection type
 struct rosidl_typesupport_introspection_c__MessageMembers_s;
@@ -99,6 +101,14 @@ uint8_t detect_action_event_type(
   const char * topic_name,
   bool is_publisher,
   bool is_start_event) noexcept;
+
+/// Get the current thread ID as a uint64_t
+/// Uses std::hash for portability — not guaranteed unique but consistent per thread
+inline uint64_t get_current_thread_id() noexcept
+{
+  return static_cast<uint64_t>(
+    std::hash<std::thread::id>{}(std::this_thread::get_id()));
+}
 
 /// Convert DDS GID to hex string for correlation
 /// @param gid DDS publisher GUID (24 bytes)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/src/rmw_client.cpp
+++ b/src/rmw_client.cpp
@@ -23,6 +23,7 @@
 #include "rmw_robotops/config.hpp"
 #include "rmw_robotops/span_id_generator.hpp"
 #include "rmw_robotops/trace_context.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
@@ -437,6 +438,27 @@ rmw_take_response(
         record_trace_failure();
       } else {
         record_trace_success();
+      }
+
+      // Emit CONTEXT_ENTERED so robot_agent can correlate /rosout logs with this trace (ROB-179)
+      {
+        rmw_robotops::TraceContextChangeEvent ctx_event;
+        ctx_event.timestamp_ns = event.timestamp_ns;
+        ctx_event.thread_id = rmw_robotops::get_current_thread_id();
+        ctx_event.change_type = rmw_robotops::CONTEXT_CHANGE_ENTERED;
+        std::memcpy(ctx_event.trace_id, new_context.trace_id,
+          sizeof(ctx_event.trace_id) - 1);
+        ctx_event.trace_id[sizeof(ctx_event.trace_id) - 1] = '\0';
+        std::memcpy(ctx_event.span_id, new_context.span_id,
+          sizeof(ctx_event.span_id) - 1);
+        ctx_event.span_id[sizeof(ctx_event.span_id) - 1] = '\0';
+        std::memcpy(ctx_event.node_name, event.node_name,
+          sizeof(ctx_event.node_name) - 1);
+        ctx_event.node_name[sizeof(ctx_event.node_name) - 1] = '\0';
+        std::memcpy(ctx_event.node_namespace, event.node_namespace,
+          sizeof(ctx_event.node_namespace) - 1);
+        ctx_event.node_namespace[sizeof(ctx_event.node_namespace) - 1] = '\0';
+        rmw_robotops::enqueue_context_change(ctx_event);
       }
     } catch (...) {
       record_trace_failure();

--- a/src/rmw_init.cpp
+++ b/src/rmw_init.cpp
@@ -23,6 +23,7 @@
 #include "rmw/security_options.h"
 #include "rmw_robotops/config.hpp"
 #include "rmw_robotops/diagnostics_publisher.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
 #include "rmw_robotops/trace_publisher.hpp"
 
 // Function pointers to underlying RMW implementation
@@ -226,6 +227,12 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     fprintf(stderr, "rmw_robotops: Warning: Failed to start trace publisher\n");
   }
 
+  // Start background trace context change publisher (only if tracing enabled)
+  ret = rmw_robotops::start_trace_context_change_publisher(context);
+  if (ret != RMW_RET_OK) {
+    fprintf(stderr, "rmw_robotops: Warning: Failed to start trace context change publisher\n");
+  }
+
   // Start background diagnostics publisher (only if diagnostics enabled)
   ret = rmw_robotops::start_diagnostics_publisher(context);
   if (ret != RMW_RET_OK) {
@@ -243,6 +250,12 @@ rmw_shutdown(rmw_context_t * context)
   rmw_ret_t ret = rmw_robotops::stop_diagnostics_publisher();
   if (ret != RMW_RET_OK) {
     fprintf(stderr, "rmw_robotops: Warning: Error stopping diagnostics publisher\n");
+  }
+
+  // Stop trace context change publisher
+  ret = rmw_robotops::stop_trace_context_change_publisher();
+  if (ret != RMW_RET_OK) {
+    fprintf(stderr, "rmw_robotops: Warning: Error stopping trace context change publisher\n");
   }
 
   // Then stop trace publisher (drains remaining events)

--- a/src/rmw_publisher.cpp
+++ b/src/rmw_publisher.cpp
@@ -24,6 +24,7 @@
 #include "rmw_robotops/diagnostics_metrics.hpp"
 #include "rmw_robotops/span_id_generator.hpp"
 #include "rmw_robotops/trace_context.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
@@ -354,6 +355,22 @@ rmw_publish(
         record_trace_success();
         rmw_robotops::increment_traces_emitted();
         rmw_robotops::increment_traces_emitted();  // Two events emitted (start + end)
+      }
+
+      // Emit CONTEXT_EXITED — the callback that triggered this publish is done (ROB-179)
+      {
+        rmw_robotops::TraceContextChangeEvent ctx_event;
+        ctx_event.timestamp_ns = start_event.timestamp_ns;
+        ctx_event.thread_id = rmw_robotops::get_current_thread_id();
+        ctx_event.change_type = rmw_robotops::CONTEXT_CHANGE_EXITED;
+        std::memcpy(ctx_event.node_name, start_event.node_name,
+          sizeof(ctx_event.node_name) - 1);
+        ctx_event.node_name[sizeof(ctx_event.node_name) - 1] = '\0';
+        std::memcpy(ctx_event.node_namespace, start_event.node_namespace,
+          sizeof(ctx_event.node_namespace) - 1);
+        ctx_event.node_namespace[sizeof(ctx_event.node_namespace) - 1] = '\0';
+        // trace_id and span_id remain empty — not needed for CONTEXT_EXITED
+        rmw_robotops::enqueue_context_change(ctx_event);
       }
     } catch (...) {
       record_trace_failure();

--- a/src/rmw_service.cpp
+++ b/src/rmw_service.cpp
@@ -23,6 +23,7 @@
 #include "rmw_robotops/config.hpp"
 #include "rmw_robotops/span_id_generator.hpp"
 #include "rmw_robotops/trace_context.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
@@ -272,6 +273,27 @@ rmw_take_request(
       } else {
         record_trace_success();
       }
+
+      // Emit CONTEXT_ENTERED so robot_agent can correlate /rosout logs with this trace (ROB-179)
+      {
+        rmw_robotops::TraceContextChangeEvent ctx_event;
+        ctx_event.timestamp_ns = event.timestamp_ns;
+        ctx_event.thread_id = rmw_robotops::get_current_thread_id();
+        ctx_event.change_type = rmw_robotops::CONTEXT_CHANGE_ENTERED;
+        std::memcpy(ctx_event.trace_id, new_context.trace_id,
+          sizeof(ctx_event.trace_id) - 1);
+        ctx_event.trace_id[sizeof(ctx_event.trace_id) - 1] = '\0';
+        std::memcpy(ctx_event.span_id, new_context.span_id,
+          sizeof(ctx_event.span_id) - 1);
+        ctx_event.span_id[sizeof(ctx_event.span_id) - 1] = '\0';
+        std::memcpy(ctx_event.node_name, event.node_name,
+          sizeof(ctx_event.node_name) - 1);
+        ctx_event.node_name[sizeof(ctx_event.node_name) - 1] = '\0';
+        std::memcpy(ctx_event.node_namespace, event.node_namespace,
+          sizeof(ctx_event.node_namespace) - 1);
+        ctx_event.node_namespace[sizeof(ctx_event.node_namespace) - 1] = '\0';
+        rmw_robotops::enqueue_context_change(ctx_event);
+      }
     } catch (...) {
       record_trace_failure();
     }
@@ -385,6 +407,22 @@ rmw_send_response(
         record_trace_failure();
       } else {
         record_trace_success();
+      }
+
+      // Emit CONTEXT_EXITED — the service handler is done processing (ROB-179)
+      {
+        rmw_robotops::TraceContextChangeEvent ctx_event;
+        ctx_event.timestamp_ns = event.timestamp_ns;
+        ctx_event.thread_id = rmw_robotops::get_current_thread_id();
+        ctx_event.change_type = rmw_robotops::CONTEXT_CHANGE_EXITED;
+        std::memcpy(ctx_event.node_name, event.node_name,
+          sizeof(ctx_event.node_name) - 1);
+        ctx_event.node_name[sizeof(ctx_event.node_name) - 1] = '\0';
+        std::memcpy(ctx_event.node_namespace, event.node_namespace,
+          sizeof(ctx_event.node_namespace) - 1);
+        ctx_event.node_namespace[sizeof(ctx_event.node_namespace) - 1] = '\0';
+        // trace_id and span_id remain empty — not needed for CONTEXT_EXITED
+        rmw_robotops::enqueue_context_change(ctx_event);
       }
     } catch (...) {
       record_trace_failure();

--- a/src/rmw_subscription.cpp
+++ b/src/rmw_subscription.cpp
@@ -24,6 +24,7 @@
 #include "rmw_robotops/diagnostics_metrics.hpp"
 #include "rmw_robotops/span_id_generator.hpp"
 #include "rmw_robotops/trace_context.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
@@ -414,6 +415,27 @@ rmw_take_with_info(
         record_trace_success();
         rmw_robotops::increment_traces_emitted();
         rmw_robotops::increment_traces_emitted();  // Two events emitted (start + end)
+      }
+
+      // Emit CONTEXT_ENTERED so robot_agent can correlate /rosout logs with this trace (ROB-179)
+      {
+        rmw_robotops::TraceContextChangeEvent ctx_event;
+        ctx_event.timestamp_ns = start_event.timestamp_ns;
+        ctx_event.thread_id = rmw_robotops::get_current_thread_id();
+        ctx_event.change_type = rmw_robotops::CONTEXT_CHANGE_ENTERED;
+        std::memcpy(ctx_event.trace_id, new_context.trace_id,
+          sizeof(ctx_event.trace_id) - 1);
+        ctx_event.trace_id[sizeof(ctx_event.trace_id) - 1] = '\0';
+        std::memcpy(ctx_event.span_id, new_context.span_id,
+          sizeof(ctx_event.span_id) - 1);
+        ctx_event.span_id[sizeof(ctx_event.span_id) - 1] = '\0';
+        std::memcpy(ctx_event.node_name, start_event.node_name,
+          sizeof(ctx_event.node_name) - 1);
+        ctx_event.node_name[sizeof(ctx_event.node_name) - 1] = '\0';
+        std::memcpy(ctx_event.node_namespace, start_event.node_namespace,
+          sizeof(ctx_event.node_namespace) - 1);
+        ctx_event.node_namespace[sizeof(ctx_event.node_namespace) - 1] = '\0';
+        rmw_robotops::enqueue_context_change(ctx_event);
       }
     } catch (...) {
       record_trace_failure();

--- a/src/trace_context_change_publisher.cpp
+++ b/src/trace_context_change_publisher.cpp
@@ -1,0 +1,280 @@
+// Copyright 2025 Robot Ops Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+#include "rmw/error_handling.h"
+#include "rmw/rmw.h"
+#include "rmw_robotops/config.hpp"
+#include "rmw_robotops/trace_context_change_publisher.hpp"
+#include "robotops_msgs/msg/trace_context_change.h"
+#include "rosidl_runtime_c/string_functions.h"
+
+// Forward declarations of underlying RMW functions (defined in rmw_init.cpp)
+extern "C" {
+extern rmw_node_t * (* underlying_rmw_create_node)(
+  rmw_context_t *, const char *, const char *);
+extern rmw_ret_t (* underlying_rmw_destroy_node)(rmw_node_t *);
+extern rmw_publisher_t * (* underlying_rmw_create_publisher)(
+  const rmw_node_t *, const rosidl_message_type_support_t *,
+  const char *, const rmw_qos_profile_t *, const rmw_publisher_options_t *);
+extern rmw_ret_t (* underlying_rmw_destroy_publisher)(
+  rmw_node_t *, rmw_publisher_t *);
+extern rmw_ret_t (* underlying_rmw_publish)(
+  const rmw_publisher_t *, const void *, rmw_publisher_allocation_t *);
+}
+
+namespace rmw_robotops
+{
+
+namespace
+{
+
+/// MPSC lock-free ring buffer for TraceContextChangeEvent
+/// Capacity must be a power of two for correct ring arithmetic
+template<size_t Capacity>
+class ContextChangeQueue
+{
+public:
+  ContextChangeQueue() noexcept
+  : head_(0), tail_(0) {}
+
+  /// Try to push (non-blocking). Returns false if full.
+  bool try_push(const TraceContextChangeEvent & event) noexcept
+  {
+    size_t current_tail = tail_.load(std::memory_order_relaxed);
+
+    for (int attempts = 0; attempts < 100; ++attempts) {
+      const size_t next_tail = (current_tail + 1) % Capacity;
+      const size_t current_head = head_.load(std::memory_order_acquire);
+
+      if (next_tail == current_head) {
+        return false;  // Queue full
+      }
+
+      if (tail_.compare_exchange_weak(
+          current_tail,
+          next_tail,
+          std::memory_order_release,
+          std::memory_order_relaxed))
+      {
+        buffer_[current_tail] = event;
+        return true;
+      }
+
+      std::this_thread::yield();
+    }
+
+    return false;  // Too much contention
+  }
+
+  /// Try to pop (non-blocking, single-consumer only). Returns false if empty.
+  bool try_pop(TraceContextChangeEvent & event) noexcept
+  {
+    const size_t current_head = head_.load(std::memory_order_relaxed);
+    const size_t current_tail = tail_.load(std::memory_order_acquire);
+
+    if (current_head == current_tail) {
+      return false;  // Queue empty
+    }
+
+    event = buffer_[current_head];
+    head_.store((current_head + 1) % Capacity, std::memory_order_release);
+    return true;
+  }
+
+private:
+  TraceContextChangeEvent buffer_[Capacity];
+  std::atomic<size_t> head_;
+  std::atomic<size_t> tail_;
+};
+
+constexpr size_t CONTEXT_CHANGE_QUEUE_SIZE = 512;
+
+// Background publisher state
+std::atomic<bool> context_change_running{false};
+std::thread context_change_thread;
+rmw_node_t * context_change_node = nullptr;
+rmw_publisher_t * context_change_publisher = nullptr;
+ContextChangeQueue<CONTEXT_CHANGE_QUEUE_SIZE> context_change_queue;
+
+/// Convert internal event to ROS2 C message.
+/// Memory allocation is fine here — this runs in the background thread.
+bool convert_to_ros_message(
+  const TraceContextChangeEvent & event,
+  robotops_msgs__msg__TraceContextChange & msg) noexcept
+{
+  try {
+    msg.timestamp.sec = static_cast<int32_t>(event.timestamp_ns / 1000000000ULL);
+    msg.timestamp.nanosec = static_cast<uint32_t>(event.timestamp_ns % 1000000000ULL);
+    rosidl_runtime_c__String__assign(&msg.node_name, event.node_name);
+    rosidl_runtime_c__String__assign(&msg.node_namespace, event.node_namespace);
+    msg.thread_id = event.thread_id;
+    rosidl_runtime_c__String__assign(&msg.trace_id, event.trace_id);
+    rosidl_runtime_c__String__assign(&msg.span_id, event.span_id);
+    msg.change_type = event.change_type;
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+/// Background thread: drains the queue and publishes to /robotops/trace_context
+void context_change_thread_func() noexcept
+{
+  robotops_msgs__msg__TraceContextChange msg;
+  robotops_msgs__msg__TraceContextChange__init(&msg);
+
+  while (context_change_running.load(std::memory_order_relaxed)) {
+    TraceContextChangeEvent event;
+    if (context_change_queue.try_pop(event)) {
+      if (convert_to_ros_message(event, msg)) {
+        if (context_change_publisher != nullptr && underlying_rmw_publish != nullptr) {
+          underlying_rmw_publish(context_change_publisher, &msg, nullptr);
+        }
+        robotops_msgs__msg__TraceContextChange__fini(&msg);
+        robotops_msgs__msg__TraceContextChange__init(&msg);
+      }
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  // Drain remaining events before shutdown
+  TraceContextChangeEvent event;
+  while (context_change_queue.try_pop(event)) {
+    if (convert_to_ros_message(event, msg)) {
+      if (context_change_publisher != nullptr && underlying_rmw_publish != nullptr) {
+        underlying_rmw_publish(context_change_publisher, &msg, nullptr);
+      }
+      robotops_msgs__msg__TraceContextChange__fini(&msg);
+      robotops_msgs__msg__TraceContextChange__init(&msg);
+    }
+  }
+
+  robotops_msgs__msg__TraceContextChange__fini(&msg);
+}
+
+}  // anonymous namespace
+
+bool enqueue_context_change(const TraceContextChangeEvent & event) noexcept
+{
+  return context_change_queue.try_push(event);
+}
+
+rmw_ret_t start_trace_context_change_publisher(rmw_context_t * context) noexcept
+{
+  if (context_change_running.load(std::memory_order_relaxed)) {
+    return RMW_RET_OK;  // Idempotent
+  }
+
+  if (!is_tracing_enabled()) {
+    return RMW_RET_OK;  // No-op when tracing disabled
+  }
+
+  if (underlying_rmw_create_node == nullptr) {
+    RMW_SET_ERROR_MSG("Underlying RMW not initialized");
+    return RMW_RET_ERROR;
+  }
+
+  context_change_node = underlying_rmw_create_node(
+    context, "rmw_robotops_context_change", "/robotops");
+  if (context_change_node == nullptr) {
+    RMW_SET_ERROR_MSG("Failed to create trace context change publisher node");
+    return RMW_RET_ERROR;
+  }
+
+  const rosidl_message_type_support_t * type_support =
+    ROSIDL_GET_MSG_TYPE_SUPPORT(robotops_msgs, msg, TraceContextChange);
+  if (type_support == nullptr) {
+    underlying_rmw_destroy_node(context_change_node);
+    context_change_node = nullptr;
+    RMW_SET_ERROR_MSG("Failed to get TraceContextChange type support");
+    return RMW_RET_ERROR;
+  }
+
+  rmw_qos_profile_t qos = rmw_qos_profile_default;
+  qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  qos.depth = 50;
+
+  rmw_publisher_options_t pub_options = rmw_get_default_publisher_options();
+
+  if (underlying_rmw_create_publisher == nullptr) {
+    underlying_rmw_destroy_node(context_change_node);
+    context_change_node = nullptr;
+    RMW_SET_ERROR_MSG("Underlying RMW create_publisher not available");
+    return RMW_RET_ERROR;
+  }
+
+  context_change_publisher = underlying_rmw_create_publisher(
+    context_change_node, type_support, "/robotops/trace_context", &qos, &pub_options);
+
+  if (context_change_publisher == nullptr) {
+    underlying_rmw_destroy_node(context_change_node);
+    context_change_node = nullptr;
+    RMW_SET_ERROR_MSG("Failed to create trace context change publisher");
+    return RMW_RET_ERROR;
+  }
+
+  context_change_running.store(true, std::memory_order_relaxed);
+  try {
+    context_change_thread = std::thread(context_change_thread_func);
+  } catch (...) {
+    context_change_running.store(false, std::memory_order_relaxed);
+    underlying_rmw_destroy_publisher(context_change_node, context_change_publisher);
+    underlying_rmw_destroy_node(context_change_node);
+    context_change_publisher = nullptr;
+    context_change_node = nullptr;
+    RMW_SET_ERROR_MSG("Failed to start trace context change publisher thread");
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t stop_trace_context_change_publisher() noexcept
+{
+  if (!context_change_running.load(std::memory_order_relaxed)) {
+    return RMW_RET_OK;  // Idempotent
+  }
+
+  context_change_running.store(false, std::memory_order_relaxed);
+
+  if (context_change_thread.joinable()) {
+    try {
+      context_change_thread.join();
+    } catch (...) {
+      // Safety guarantee: Never propagate exceptions
+    }
+  }
+
+  if (context_change_publisher != nullptr && underlying_rmw_destroy_publisher != nullptr) {
+    underlying_rmw_destroy_publisher(context_change_node, context_change_publisher);
+    context_change_publisher = nullptr;
+  }
+
+  if (context_change_node != nullptr && underlying_rmw_destroy_node != nullptr) {
+    underlying_rmw_destroy_node(context_change_node);
+    context_change_node = nullptr;
+  }
+
+  return RMW_RET_OK;
+}
+
+}  // namespace rmw_robotops


### PR DESCRIPTION
…e correlation (ROB-179)

Adds a new background publisher that emits TraceContextChange messages to /robotops/trace_context whenever thread-local trace context is set or cleared. This fills the gap identified in ROB-179: robot_agent was already subscribed to this topic, but rmw_robotops never published to it, so /rosout logs were never correlated with trace spans.

New files:
- include/rmw_robotops/trace_context_change_publisher.hpp
- src/trace_context_change_publisher.cpp (MPSC ring buffer 512 slots, background thread, hidden ROS2 node, best-effort QoS — follows trace_publisher.cpp pattern)

Call sites now emit:
- CONTEXT_ENTERED in rmw_take_with_info, rmw_take_request, rmw_take_response (after set_trace_context sets the new context, using node metadata from cache)
- CONTEXT_EXITED in rmw_publish and rmw_send_response (after the downstream operation completes)

Also adds get_current_thread_id() utility to utils.hpp for multi-threaded executor support.