### PR TITLE
feat(demo-agent): align Parquet schema with ROSQL OtelPostgres profile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.1 (2026-04-19)
+-------------------
+
+* ``demo-agent``: align Parquet output schema with ROSQL OtelPostgres profile (GH-43)
+
+  * ``otel_traces``: add ``timestamp`` (``TIMESTAMPTZ`` / ``Timestamp(Microsecond, UTC)``), ``service_name``, ``span_attributes`` (JSON), ``resource_attributes`` (JSON); rename ``duration_ns`` → ``duration``; ``parent_span_id`` is now a non-nullable string (empty = no parent)
+  * ``otel_logs``: add ``timestamp``, ``service_name``, ``resource_attributes``, ``log_attributes`` (JSON, contains ``logger.name``, ``code.*``); rename ``severity`` → ``severity_text``
+  * Subscribe spans now carry the correlated publish span as ``parent_span_id`` — enables ROSQL ``PATH DEVIATION`` and ``TRACE`` queries
+  * ``service_name`` derived per-span from ROS2 node namespace + node name (e.g. ``/talker``)
+  * Add ``--robot-id`` / ``--organization-id`` CLI flags (also ``ROBOTOPS_ROBOT_ID`` / ``ROBOTOPS_ORG_ID``) to populate ``resource_attributes`` for ROSQL ``WHERE robot_id = '...'`` filters
+  * ROS2-specific flat columns retained as extras after the core columns (ROSQL ignores them)
+
 0.9.0 (2026-04-03)
 -------------------
 

--- a/demo-agent/README.md
+++ b/demo-agent/README.md
@@ -140,7 +140,7 @@ LIMIT 20"
 duckdb -c "
 SELECT trace_id, span_id, severity_text, body
 FROM read_parquet('./telemetry/robotops_demo_agent/*/logs/*.parquet')
-ORDER BY observed_time_ns DESC
+ORDER BY timestamp DESC
 LIMIT 20"
 
 # Join traces and logs for a specific trace
@@ -173,6 +173,8 @@ rosql query "FROM traces WHERE status = 'ERROR' SINCE 5 min ago" \
 | `--correlation-window-secs` | `30` | `ROBOTOPS_DEMO_CORRELATION_WINDOW_SECS` | How long to keep unmatched publish events |
 | `--correlation-tolerance-ns` | `10000000` | `ROBOTOPS_DEMO_CORRELATION_TOLERANCE_NS` | Timestamp tolerance for cross-process correlation (ns) |
 | `--domain-id` | `0` | `ROS_DOMAIN_ID` | ROS2 domain ID |
+| `--robot-id` | _(empty)_ | `ROBOTOPS_ROBOT_ID` | Robot identifier written to `resource_attributes["robot.id"]` (used by ROSQL `WHERE robot_id = '...'`) |
+| `--organization-id` | _(empty)_ | `ROBOTOPS_ORG_ID` | Organization identifier written to `resource_attributes["organization.id"]` |
 
 ### S3 environment variables
 
@@ -203,50 +205,59 @@ Files are written under:
 
 Each file is write-once. New files are created on each flush when the buffer is non-empty. Use glob patterns to query across all files in a session or across sessions.
 
-### Traces schema (24 columns, OTel-compatible)
+### Traces schema — ROSQL OtelPostgres-compatible
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `trace_id` | String | 16-byte hex trace ID |
-| `span_id` | String | 8-byte hex span ID |
-| `parent_span_id` | String (nullable) | Parent span ID |
-| `span_name` | String | Operation name (topic or service) |
-| `span_kind` | String | `PRODUCER`, `CONSUMER`, `CLIENT`, `SERVER`, `INTERNAL` |
-| `start_time_ns` | Int64 | Span start (Unix nanoseconds) |
-| `end_time_ns` | Int64 | Span end (Unix nanoseconds) |
-| `duration_ns` | Int64 | `end_time_ns - start_time_ns` |
+The schema is a **superset** of the [ROSQL OtelPostgres profile](https://rosql.org). The core columns come first (used by ROSQL queries), followed by ROS2-specific extras that ROSQL ignores.
+
+**Core columns (ROSQL OtelPostgres profile)**
+
+| Column | Arrow type | Description |
+|--------|-----------|-------------|
+| `timestamp` | `Timestamp(Microsecond, UTC)` | Span start time — used by ROSQL `SINCE`/`UNTIL` |
+| `trace_id` | String | Hex trace ID |
+| `span_id` | String | Hex span ID |
+| `parent_span_id` | String | Parent span ID (`""` when none; subscribe spans get the cross-process publish span as parent) |
+| `span_name` | String | e.g. `publish /chatter` |
+| `span_kind` | String | `PRODUCER`, `CONSUMER`, `SERVER`, `INTERNAL` |
+| `service_name` | String | Derived from ROS2 node: `/{namespace}/{node_name}` |
+| `duration` | Int64 | Span duration in nanoseconds |
 | `status_code` | String | `OK`, `ERROR`, `UNSET` |
-| `status_message` | String (nullable) | Error message |
-| `node_name` | String | ROS2 node name |
-| `node_namespace` | String | ROS2 node namespace |
-| `topic_name` | String | Topic or service name |
-| `publisher_gid` | String (nullable) | Publisher GID (hex) |
-| `content_hash` | UInt64 (nullable) | FNV-1a content hash for correlation |
-| `rmw_implementation` | String | Underlying RMW (e.g. `rmw_fastrtps_cpp`) |
-| `host_name` | String (nullable) | Hostname |
-| `process_id` | UInt32 (nullable) | PID |
-| `span_links` | String (nullable) | JSON array of linked span IDs |
-| `service_name` | String | OTel service name |
-| `resource_attributes` | String (nullable) | JSON resource attributes |
-| `span_attributes` | String (nullable) | JSON span attributes |
-| `events` | String (nullable) | JSON span events |
-| `observed_time_ns` | Int64 | When the agent recorded this span |
+| `span_attributes` | String (JSON) | ROS2 attributes: `ros.node`, `ros.topic`, `ros.message_type`, `ros.publisher_gid`, `ros.content_hash`, `ros.sequence_number`, `ros.source_timestamp_ns`, `ros.message_size_bytes`, `ros.dds.domain_id`, `ros.correlation_method`, `ros.correlation.publish_span_id` |
+| `resource_attributes` | String (JSON) | `robot.id`, `organization.id` (set via `--robot-id` / `--organization-id`) |
 
-### Logs schema (11 columns, OTel-compatible)
+**Extra columns (ROS2-specific, not used by ROSQL)**
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `trace_id` | String (nullable) | Correlated trace ID |
-| `span_id` | String (nullable) | Correlated span ID |
-| `severity_number` | UInt8 | OTel severity number (1–24) |
+`operation`, `start_time_ns`, `end_time_ns`, `ros_topic`, `ros_node_name`, `ros_node_namespace`, `ros_message_type`, `ros_publisher_gid`, `ros_content_hash`, `ros_sequence_number`, `ros_source_timestamp_ns`, `ros_message_size_bytes`, `ros_dds_domain_id`, `ros_correlation_method`, `correlated_publish_span_id`, `span_links`, `written_at_ns`.
+
+**Example ROSQL queries:**
+
+```bash
+# Filter by topic using span_attributes JSON extraction
+rosql "FROM traces WHERE topic = '/chatter' SINCE 5m" --backend parquet --url ./telemetry/robotops_demo_agent/<session>
+
+# Filter by robot
+rosql "FROM traces WHERE robot_id = 'my-robot-01' SINCE 1h" --backend parquet --url ./telemetry/...
+
+# Raw DuckDB
+duckdb -c "SELECT service_name, span_name, span_attributes->>'ros.topic' AS topic
+           FROM read_parquet('./telemetry/robotops_demo_agent/*/traces/*.parquet')
+           WHERE timestamp > NOW() - INTERVAL 5 MINUTE"
+```
+
+### Logs schema — ROSQL OtelPostgres-compatible
+
+| Column | Arrow type | Description |
+|--------|-----------|-------------|
+| `timestamp` | `Timestamp(Microsecond, UTC)` | Log emit time |
+| `trace_id` | String | Correlated trace ID (`""` when absent) |
+| `span_id` | String | Correlated span ID (`""` when absent) |
 | `severity_text` | String | `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL` |
+| `severity_number` | Int32 | OTel severity number (1–24) |
+| `service_name` | String | ROS2 logger name (proxy for service) |
 | `body` | String | Log message text |
-| `logger_name` | String | ROS2 logger name |
-| `node_name` | String | ROS2 node name |
-| `code_function` | String (nullable) | Source function name |
-| `code_lineno` | Int32 (nullable) | Source line number |
-| `service_name` | String | OTel service name |
-| `observed_time_ns` | Int64 | When the agent recorded this log |
+| `resource_attributes` | String (JSON) | Same as traces (`robot.id`, `organization.id`) |
+| `log_attributes` | String (JSON) | `logger.name`, `code.filepath`, `code.function`, `code.lineno` |
+| `written_at_ns` | Int64 | When the agent wrote this record (debug) |
 
 ---
 

--- a/demo-agent/src/cli.rs
+++ b/demo-agent/src/cli.rs
@@ -65,4 +65,14 @@ pub struct Cli {
     /// ROS2 domain ID. Defaults to ROS_DOMAIN_ID environment variable, or 0.
     #[arg(long, env = "ROS_DOMAIN_ID")]
     pub domain_id: Option<u32>,
+
+    /// Robot identifier written to resource_attributes["robot.id"] in Parquet.
+    /// Used by ROSQL `WHERE robot_id = '...'` filters.
+    #[arg(long, default_value = "", env = "ROBOTOPS_ROBOT_ID")]
+    pub robot_id: String,
+
+    /// Organization identifier written to resource_attributes["organization.id"].
+    /// Used by ROSQL `WHERE org_id = '...'` filters.
+    #[arg(long, default_value = "", env = "ROBOTOPS_ORG_ID")]
+    pub organization_id: String,
 }

--- a/demo-agent/src/export/parquet.rs
+++ b/demo-agent/src/export/parquet.rs
@@ -7,16 +7,15 @@
 //!   <base>/robotops_demo_agent/<yyyymmdd-hhmmss>/traces/part-0001.parquet
 //!   <base>/robotops_demo_agent/<yyyymmdd-hhmmss>/logs/part-0001.parquet
 //!
-//! Files are write-once. DuckDB/ROSQL can glob-query them:
-//!   SELECT * FROM read_parquet('<session>/traces/*.parquet')
+//! Schema conforms to the ROSQL OtelPostgres profile so that ROSQL queries work
+//! out of the box with `--backend parquet`. ROS2-specific fields are appended as
+//! extra columns after the core OtelPostgres columns; ROSQL ignores them.
 
 use crate::error::{BridgeError, Result};
 use crate::export::SpanExporter;
 use crate::pipeline::otel_builder::{OtelLog, OtelSpan};
-use arrow::array::{
-    ArrayRef, Int32Array, Int64Array, StringArray, UInt32Array, UInt64Array, UInt8Array,
-};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{ArrayRef, Int32Array, Int64Array, StringArray, TimestampMicrosecondArray, UInt32Array, UInt64Array, UInt8Array};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use chrono::Utc;
 use object_store::{path::Path as OsPath, ObjectStore};
@@ -28,21 +27,31 @@ use std::sync::Arc;
 use tracing::debug;
 
 // ---------------------------------------------------------------------------
-// Arrow schemas
+// Arrow schemas  (OtelPostgres core columns first, ROS extras after)
 // ---------------------------------------------------------------------------
 
 fn traces_schema() -> Schema {
     Schema::new(vec![
+        // ── OtelPostgres core ──────────────────────────────────────────
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("UTC"))),
+            false,
+        ),
         Field::new("trace_id", DataType::Utf8, false),
         Field::new("span_id", DataType::Utf8, false),
-        Field::new("parent_span_id", DataType::Utf8, true),
-        Field::new("operation", DataType::Utf8, false),
+        Field::new("parent_span_id", DataType::Utf8, false),
         Field::new("span_name", DataType::Utf8, false),
         Field::new("span_kind", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("duration", DataType::Int64, false),
+        Field::new("status_code", DataType::Utf8, false),
+        Field::new("span_attributes", DataType::Utf8, false),
+        Field::new("resource_attributes", DataType::Utf8, false),
+        // ── ROS2-specific extras (ignored by ROSQL, useful for local analysis) ──
+        Field::new("operation", DataType::Utf8, false),
         Field::new("start_time_ns", DataType::Int64, false),
         Field::new("end_time_ns", DataType::Int64, false),
-        Field::new("duration_ns", DataType::Int64, false),
-        Field::new("status_code", DataType::Utf8, false),
         Field::new("ros_topic", DataType::Utf8, true),
         Field::new("ros_node_name", DataType::Utf8, false),
         Field::new("ros_node_namespace", DataType::Utf8, false),
@@ -62,16 +71,21 @@ fn traces_schema() -> Schema {
 
 fn logs_schema() -> Schema {
     Schema::new(vec![
-        Field::new("timestamp_ns", DataType::Int64, false),
-        Field::new("severity", DataType::Utf8, false),
+        // ── OtelPostgres core ──────────────────────────────────────────
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("UTC"))),
+            false,
+        ),
+        Field::new("trace_id", DataType::Utf8, false),
+        Field::new("span_id", DataType::Utf8, false),
+        Field::new("severity_text", DataType::Utf8, false),
         Field::new("severity_number", DataType::Int32, false),
+        Field::new("service_name", DataType::Utf8, false),
         Field::new("body", DataType::Utf8, false),
-        Field::new("logger_name", DataType::Utf8, false),
-        Field::new("trace_id", DataType::Utf8, true),
-        Field::new("span_id", DataType::Utf8, true),
-        Field::new("code_filepath", DataType::Utf8, true),
-        Field::new("code_function", DataType::Utf8, true),
-        Field::new("code_lineno", DataType::Int32, true),
+        Field::new("resource_attributes", DataType::Utf8, false),
+        Field::new("log_attributes", DataType::Utf8, false),
+        // ── Extra for debugging ────────────────────────────────────────
         Field::new("written_at_ns", DataType::Int64, false),
     ])
 }
@@ -90,12 +104,18 @@ pub struct ParquetExporter {
     log_part: u32,
     bytes_written: u64,
     limit_bytes: u64,
+    resource_attrs_json: String,
     rt: tokio::runtime::Runtime,
 }
 
 impl ParquetExporter {
     /// Create a new exporter writing to `output` (local path or `s3://bucket/prefix`).
-    pub fn new(output: &str, batch_size: usize, limit_mb: u64) -> Result<Self> {
+    pub fn new(
+        output: &str,
+        batch_size: usize,
+        limit_mb: u64,
+        resource_attrs_json: String,
+    ) -> Result<Self> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -125,6 +145,7 @@ impl ParquetExporter {
             log_part: 0,
             bytes_written: 0,
             limit_bytes: limit_mb * 1024 * 1024,
+            resource_attrs_json,
             rt,
         })
     }
@@ -139,7 +160,7 @@ impl ParquetExporter {
             return Ok(());
         }
 
-        let batch = spans_to_record_batch(&self.pending_spans)?;
+        let batch = spans_to_record_batch(&self.pending_spans, &self.resource_attrs_json)?;
         let bytes = record_batch_to_parquet(&batch)?;
         let n_bytes = bytes.len() as u64;
 
@@ -169,7 +190,7 @@ impl ParquetExporter {
             return Ok(());
         }
 
-        let batch = logs_to_record_batch(&self.pending_logs)?;
+        let batch = logs_to_record_batch(&self.pending_logs, &self.resource_attrs_json)?;
         let bytes = record_batch_to_parquet(&batch)?;
         let n_bytes = bytes.len() as u64;
 
@@ -257,46 +278,125 @@ fn build_s3_store(uri: &str) -> Result<object_store::aws::AmazonS3> {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn service_name_for(namespace: &str, node_name: &str) -> String {
+    match namespace.trim_end_matches('/') {
+        "" | "/" => format!("/{node_name}"),
+        ns => format!("{ns}/{node_name}"),
+    }
+}
+
+fn span_attributes_json(s: &OtelSpan) -> String {
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("ros.node".into(), s.ros_node_name.clone().into());
+    attrs.insert(
+        "ros.node.namespace".into(),
+        s.ros_node_namespace.clone().into(),
+    );
+    if let Some(topic) = &s.ros_topic {
+        attrs.insert("ros.topic".into(), topic.clone().into());
+    }
+    attrs.insert("ros.message_type".into(), s.ros_message_type.clone().into());
+    attrs.insert(
+        "ros.publisher_gid".into(),
+        s.ros_publisher_gid.clone().into(),
+    );
+    attrs.insert("ros.content_hash".into(), s.ros_content_hash.into());
+    attrs.insert("ros.sequence_number".into(), s.ros_sequence_number.into());
+    attrs.insert(
+        "ros.source_timestamp_ns".into(),
+        s.ros_source_timestamp_ns.into(),
+    );
+    attrs.insert(
+        "ros.message_size_bytes".into(),
+        s.ros_message_size_bytes.into(),
+    );
+    attrs.insert("ros.dds.domain_id".into(), s.ros_dds_domain_id.into());
+    attrs.insert(
+        "ros.correlation_method".into(),
+        s.ros_correlation_method.into(),
+    );
+    if let Some(pub_id) = &s.correlated_publish_span_id {
+        attrs.insert(
+            "ros.correlation.publish_span_id".into(),
+            pub_id.clone().into(),
+        );
+    }
+    serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn log_attributes_json(l: &OtelLog) -> String {
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("logger.name".into(), l.logger_name.clone().into());
+    if let Some(v) = &l.code_filepath {
+        attrs.insert("code.filepath".into(), v.clone().into());
+    }
+    if let Some(v) = &l.code_function {
+        attrs.insert("code.function".into(), v.clone().into());
+    }
+    if let Some(v) = l.code_lineno {
+        attrs.insert("code.lineno".into(), v.into());
+    }
+    serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
+}
+
+// ---------------------------------------------------------------------------
 // Arrow RecordBatch builders
 // ---------------------------------------------------------------------------
 
-fn spans_to_record_batch(spans: &[OtelSpan]) -> Result<RecordBatch> {
+fn spans_to_record_batch(spans: &[OtelSpan], resource_attrs_json: &str) -> Result<RecordBatch> {
     let now_ns = Utc::now().timestamp_nanos_opt().unwrap_or(0);
     let schema = Arc::new(traces_schema());
 
+    let span_attrs: Vec<String> = spans.iter().map(span_attributes_json).collect();
+
     let arrays: Vec<ArrayRef> = vec![
+        // ── OtelPostgres core ──────────────────────────────────────────
+        Arc::new(
+            TimestampMicrosecondArray::from_iter_values(
+                spans.iter().map(|s| s.start_time_ns / 1000),
+            )
+            .with_timezone("UTC"),
+        ),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.trace_id.as_str()),
         )),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.span_id.as_str()),
         )),
-        Arc::new(StringArray::from(
-            spans
-                .iter()
-                .map(|s| s.parent_span_id.as_deref())
-                .collect::<Vec<_>>(),
-        )),
-        Arc::new(StringArray::from_iter_values(
-            spans.iter().map(|s| s.operation.as_str()),
-        )),
+        Arc::new(StringArray::from_iter_values(spans.iter().map(|s| {
+            s.parent_span_id.as_deref().unwrap_or("")
+        }))),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.span_name.as_str()),
         )),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.span_kind.as_str()),
         )),
-        Arc::new(Int64Array::from_iter_values(
-            spans.iter().map(|s| s.start_time_ns),
-        )),
-        Arc::new(Int64Array::from_iter_values(
-            spans.iter().map(|s| s.end_time_ns),
-        )),
+        Arc::new(StringArray::from_iter_values(spans.iter().map(|s| {
+            service_name_for(&s.ros_node_namespace, &s.ros_node_name)
+        }))),
         Arc::new(Int64Array::from_iter_values(
             spans.iter().map(|s| s.duration_ns),
         )),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.status_code.as_str()),
+        )),
+        Arc::new(StringArray::from_iter_values(span_attrs.iter().map(|s| s.as_str()))),
+        Arc::new(StringArray::from_iter_values(
+            std::iter::repeat_n(resource_attrs_json, spans.len()),
+        )),
+        // ── ROS2-specific extras ────────────────────────────────────────
+        Arc::new(StringArray::from_iter_values(
+            spans.iter().map(|s| s.operation.as_str()),
+        )),
+        Arc::new(Int64Array::from_iter_values(
+            spans.iter().map(|s| s.start_time_ns),
+        )),
+        Arc::new(Int64Array::from_iter_values(
+            spans.iter().map(|s| s.end_time_ns),
         )),
         Arc::new(StringArray::from(
             spans
@@ -361,13 +461,25 @@ fn spans_to_record_batch(spans: &[OtelSpan]) -> Result<RecordBatch> {
     RecordBatch::try_new(schema, arrays).map_err(|e| BridgeError::Storage(e.to_string()))
 }
 
-fn logs_to_record_batch(logs: &[OtelLog]) -> Result<RecordBatch> {
+fn logs_to_record_batch(logs: &[OtelLog], resource_attrs_json: &str) -> Result<RecordBatch> {
     let now_ns = Utc::now().timestamp_nanos_opt().unwrap_or(0);
     let schema = Arc::new(logs_schema());
 
+    let log_attrs: Vec<String> = logs.iter().map(log_attributes_json).collect();
+
     let arrays: Vec<ArrayRef> = vec![
-        Arc::new(Int64Array::from_iter_values(
-            logs.iter().map(|l| l.timestamp_ns),
+        // ── OtelPostgres core ──────────────────────────────────────────
+        Arc::new(
+            TimestampMicrosecondArray::from_iter_values(
+                logs.iter().map(|l| l.timestamp_ns / 1000),
+            )
+            .with_timezone("UTC"),
+        ),
+        Arc::new(StringArray::from_iter_values(
+            logs.iter().map(|l| l.trace_id.as_deref().unwrap_or("")),
+        )),
+        Arc::new(StringArray::from_iter_values(
+            logs.iter().map(|l| l.span_id.as_deref().unwrap_or("")),
         )),
         Arc::new(StringArray::from_iter_values(
             logs.iter().map(|l| l.severity.as_str()),
@@ -376,36 +488,18 @@ fn logs_to_record_batch(logs: &[OtelLog]) -> Result<RecordBatch> {
             logs.iter().map(|l| l.severity_number),
         )),
         Arc::new(StringArray::from_iter_values(
+            logs.iter().map(|l| l.logger_name.as_str()),
+        )),
+        Arc::new(StringArray::from_iter_values(
             logs.iter().map(|l| l.body.as_str()),
         )),
         Arc::new(StringArray::from_iter_values(
-            logs.iter().map(|l| l.logger_name.as_str()),
+            std::iter::repeat_n(resource_attrs_json, logs.len()),
         )),
-        Arc::new(StringArray::from(
-            logs.iter()
-                .map(|l| l.trace_id.as_deref())
-                .collect::<Vec<_>>(),
+        Arc::new(StringArray::from_iter_values(
+            log_attrs.iter().map(|s| s.as_str()),
         )),
-        Arc::new(StringArray::from(
-            logs.iter()
-                .map(|l| l.span_id.as_deref())
-                .collect::<Vec<_>>(),
-        )),
-        Arc::new(StringArray::from(
-            logs.iter()
-                .map(|l| l.code_filepath.as_deref())
-                .collect::<Vec<_>>(),
-        )),
-        Arc::new(StringArray::from(
-            logs.iter()
-                .map(|l| l.code_function.as_deref())
-                .collect::<Vec<_>>(),
-        )),
-        Arc::new(Int32Array::from(
-            logs.iter()
-                .map(|l| l.code_lineno.map(|n| n as i32))
-                .collect::<Vec<_>>(),
-        )),
+        // ── Extra ──────────────────────────────────────────────────────
         Arc::new(Int64Array::from_iter_values(std::iter::repeat_n(
             now_ns,
             logs.len(),
@@ -485,25 +579,113 @@ mod tests {
     }
 
     #[test]
+    fn test_service_name_derivation() {
+        assert_eq!(service_name_for("/", "talker"), "/talker");
+        assert_eq!(service_name_for("", "talker"), "/talker");
+        assert_eq!(service_name_for("/robot_1", "talker"), "/robot_1/talker");
+        assert_eq!(service_name_for("/robot_1/", "talker"), "/robot_1/talker");
+    }
+
+    #[test]
     fn test_spans_to_record_batch() {
         let spans = vec![make_span()];
-        let batch = spans_to_record_batch(&spans).unwrap();
+        let batch = spans_to_record_batch(&spans, "{}").unwrap();
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(batch.num_columns(), 24);
+        // 11 OtelPostgres core + 17 ROS extras = 28
+        assert_eq!(batch.num_columns(), 28);
     }
 
     #[test]
     fn test_logs_to_record_batch() {
         let logs = vec![make_log()];
-        let batch = logs_to_record_batch(&logs).unwrap();
+        let batch = logs_to_record_batch(&logs, "{}").unwrap();
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(batch.num_columns(), 11);
+        // 9 OtelPostgres core + 1 extra (written_at_ns) = 10
+        assert_eq!(batch.num_columns(), 10);
+    }
+
+    #[test]
+    fn test_span_attributes_json() {
+        let span = make_span();
+        let json_str = span_attributes_json(&span);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["ros.node"], "talker");
+        assert_eq!(parsed["ros.topic"], "/chatter");
+        assert!(parsed.get("ros.correlation.publish_span_id").is_none());
+    }
+
+    #[test]
+    fn test_span_attributes_json_with_correlation() {
+        let mut span = make_span();
+        span.correlated_publish_span_id = Some("pub-span-xyz".into());
+        let json_str = span_attributes_json(&span);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["ros.correlation.publish_span_id"], "pub-span-xyz");
+    }
+
+    #[test]
+    fn test_resource_attributes_json() {
+        let spans = vec![make_span()];
+        let resource_json = r#"{"robot.id":"r1","organization.id":"o1"}"#;
+        let batch = spans_to_record_batch(&spans, resource_json).unwrap();
+        let col = batch
+            .column_by_name("resource_attributes")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(col.value(0)).unwrap();
+        assert_eq!(parsed["robot.id"], "r1");
+        assert_eq!(parsed["organization.id"], "o1");
+    }
+
+    #[test]
+    fn test_parent_promoted_for_consumer() {
+        let mut span = make_span();
+        span.span_kind = SpanKind::Consumer;
+        span.correlated_publish_span_id = Some("pub-span-abc".into());
+        // parent_span_id is None; correlated publish should appear as parent_span_id column value
+        let batch = spans_to_record_batch(&[span], "{}").unwrap();
+        let col = batch
+            .column_by_name("parent_span_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "");
+        // The publish span is already in span_attributes; parent_span_id is set on OtelSpan
+        // by otel_builder.rs (not parquet.rs) — so this test verifies the None→"" mapping.
+    }
+
+    #[test]
+    fn test_timestamp_column_type() {
+        let spans = vec![make_span()];
+        let batch = spans_to_record_batch(&spans, "{}").unwrap();
+        let schema = batch.schema();
+        let field = schema.field_with_name("timestamp").unwrap();
+        assert_eq!(
+            field.data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("UTC")))
+        );
+    }
+
+    #[test]
+    fn test_duration_column_exists() {
+        let spans = vec![make_span()];
+        let batch = spans_to_record_batch(&spans, "{}").unwrap();
+        let col = batch
+            .column_by_name("duration")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(col.value(0), 50_000);
     }
 
     #[test]
     fn test_record_batch_to_parquet_roundtrip() {
         let spans = vec![make_span()];
-        let batch = spans_to_record_batch(&spans).unwrap();
+        let batch = spans_to_record_batch(&spans, "{}").unwrap();
         let bytes = record_batch_to_parquet(&batch).unwrap();
         // Valid Parquet magic bytes: PAR1
         assert!(bytes.starts_with(b"PAR1"));
@@ -514,7 +696,8 @@ mod tests {
     #[test]
     fn test_parquet_exporter_local() {
         let dir = tempfile::tempdir().unwrap();
-        let mut exporter = ParquetExporter::new(dir.path().to_str().unwrap(), 10, 200).unwrap();
+        let mut exporter =
+            ParquetExporter::new(dir.path().to_str().unwrap(), 10, 200, "{}".into()).unwrap();
 
         exporter.export_span(&make_span()).unwrap();
         exporter.export_log(&make_log()).unwrap();
@@ -531,7 +714,8 @@ mod tests {
     fn test_storage_limit() {
         let dir = tempfile::tempdir().unwrap();
         // batch_size > 1 so auto-flush doesn't trigger; limit of 0 MB triggers on explicit flush
-        let mut exporter = ParquetExporter::new(dir.path().to_str().unwrap(), 100, 0).unwrap();
+        let mut exporter =
+            ParquetExporter::new(dir.path().to_str().unwrap(), 100, 0, "{}".into()).unwrap();
         exporter.export_span(&make_span()).unwrap();
         let result = exporter.flush();
         assert!(matches!(result, Err(BridgeError::StorageLimitReached)));

--- a/demo-agent/src/export/parquet.rs
+++ b/demo-agent/src/export/parquet.rs
@@ -14,7 +14,10 @@
 use crate::error::{BridgeError, Result};
 use crate::export::SpanExporter;
 use crate::pipeline::otel_builder::{OtelLog, OtelSpan};
-use arrow::array::{ArrayRef, Int32Array, Int64Array, StringArray, TimestampMicrosecondArray, UInt32Array, UInt64Array, UInt8Array};
+use arrow::array::{
+    ArrayRef, Int32Array, Int64Array, StringArray, TimestampMicrosecondArray, UInt32Array,
+    UInt64Array, UInt8Array,
+};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use chrono::Utc;
@@ -366,9 +369,11 @@ fn spans_to_record_batch(spans: &[OtelSpan], resource_attrs_json: &str) -> Resul
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.span_id.as_str()),
         )),
-        Arc::new(StringArray::from_iter_values(spans.iter().map(|s| {
-            s.parent_span_id.as_deref().unwrap_or("")
-        }))),
+        Arc::new(StringArray::from_iter_values(
+            spans
+                .iter()
+                .map(|s| s.parent_span_id.as_deref().unwrap_or("")),
+        )),
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.span_name.as_str()),
         )),
@@ -384,10 +389,13 @@ fn spans_to_record_batch(spans: &[OtelSpan], resource_attrs_json: &str) -> Resul
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.status_code.as_str()),
         )),
-        Arc::new(StringArray::from_iter_values(span_attrs.iter().map(|s| s.as_str()))),
         Arc::new(StringArray::from_iter_values(
-            std::iter::repeat_n(resource_attrs_json, spans.len()),
+            span_attrs.iter().map(|s| s.as_str()),
         )),
+        Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+            resource_attrs_json,
+            spans.len(),
+        ))),
         // ── ROS2-specific extras ────────────────────────────────────────
         Arc::new(StringArray::from_iter_values(
             spans.iter().map(|s| s.operation.as_str()),
@@ -470,10 +478,8 @@ fn logs_to_record_batch(logs: &[OtelLog], resource_attrs_json: &str) -> Result<R
     let arrays: Vec<ArrayRef> = vec![
         // ── OtelPostgres core ──────────────────────────────────────────
         Arc::new(
-            TimestampMicrosecondArray::from_iter_values(
-                logs.iter().map(|l| l.timestamp_ns / 1000),
-            )
-            .with_timezone("UTC"),
+            TimestampMicrosecondArray::from_iter_values(logs.iter().map(|l| l.timestamp_ns / 1000))
+                .with_timezone("UTC"),
         ),
         Arc::new(StringArray::from_iter_values(
             logs.iter().map(|l| l.trace_id.as_deref().unwrap_or("")),
@@ -493,9 +499,10 @@ fn logs_to_record_batch(logs: &[OtelLog], resource_attrs_json: &str) -> Result<R
         Arc::new(StringArray::from_iter_values(
             logs.iter().map(|l| l.body.as_str()),
         )),
-        Arc::new(StringArray::from_iter_values(
-            std::iter::repeat_n(resource_attrs_json, logs.len()),
-        )),
+        Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+            resource_attrs_json,
+            logs.len(),
+        ))),
         Arc::new(StringArray::from_iter_values(
             log_attrs.iter().map(|s| s.as_str()),
         )),

--- a/demo-agent/src/main.rs
+++ b/demo-agent/src/main.rs
@@ -50,9 +50,26 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
+    // Build resource_attributes JSON from optional CLI flags.
+    let resource_attrs_json = {
+        let mut attrs = serde_json::Map::new();
+        if !cli.robot_id.is_empty() {
+            attrs.insert("robot.id".into(), cli.robot_id.clone().into());
+        }
+        if !cli.organization_id.is_empty() {
+            attrs.insert("organization.id".into(), cli.organization_id.clone().into());
+        }
+        if attrs.is_empty() {
+            "{}".to_string()
+        } else {
+            serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
+        }
+    };
+
     // Create exporter — get session path before boxing so we can show it in the greeting
-    let parquet = ParquetExporter::new(&cli.output, cli.batch_size, cli.limit_mb)
-        .map_err(|e| anyhow::anyhow!("Failed to initialise output: {}", e))?;
+    let parquet =
+        ParquetExporter::new(&cli.output, cli.batch_size, cli.limit_mb, resource_attrs_json)
+            .map_err(|e| anyhow::anyhow!("Failed to initialise output: {}", e))?;
     let session_display = format!(
         "{}/{}",
         cli.output.trim_end_matches('/'),

--- a/demo-agent/src/main.rs
+++ b/demo-agent/src/main.rs
@@ -67,9 +67,13 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create exporter — get session path before boxing so we can show it in the greeting
-    let parquet =
-        ParquetExporter::new(&cli.output, cli.batch_size, cli.limit_mb, resource_attrs_json)
-            .map_err(|e| anyhow::anyhow!("Failed to initialise output: {}", e))?;
+    let parquet = ParquetExporter::new(
+        &cli.output,
+        cli.batch_size,
+        cli.limit_mb,
+        resource_attrs_json,
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to initialise output: {}", e))?;
     let session_display = format!(
         "{}/{}",
         cli.output.trim_end_matches('/'),

--- a/demo-agent/src/pipeline/otel_builder.rs
+++ b/demo-agent/src/pipeline/otel_builder.rs
@@ -66,10 +66,18 @@ impl OtelSpan {
     pub fn from_span(span: ReconstructedSpan, correlated_publish_span_id: Option<String>) -> Self {
         let kind = span_kind_for(&span.operation);
         let span_name = format!("{} {}", span.operation, span.topic_or_service);
-        let parent = if span.parent_span_id.is_empty() {
+        let tls_parent = if span.parent_span_id.is_empty() {
             None
         } else {
             Some(span.parent_span_id.clone())
+        };
+        // For CONSUMER (subscribe) spans, the correlated publish span is the meaningful
+        // cross-process parent for ROSQL PATH/TRACE queries. Subscribe callbacks are
+        // entry points in the receiving process so promoting the publish span here is safe.
+        let parent_span_id = if kind == SpanKind::Consumer {
+            correlated_publish_span_id.clone().or(tls_parent)
+        } else {
+            tls_parent
         };
         let topic = if span.topic_or_service.is_empty() {
             None
@@ -80,7 +88,7 @@ impl OtelSpan {
         OtelSpan {
             trace_id: span.trace_id,
             span_id: span.span_id,
-            parent_span_id: parent,
+            parent_span_id,
             operation: span.operation,
             span_name,
             span_kind: kind,
@@ -190,6 +198,16 @@ mod tests {
             otel.correlated_publish_span_id,
             Some("pub-span-123".to_string())
         );
+        // Publish span is promoted to parent_span_id for cross-process trace linkage.
+        assert_eq!(otel.parent_span_id, Some("pub-span-123".to_string()));
+    }
+
+    #[test]
+    fn test_subscribe_without_correlation_uses_tls_parent() {
+        let otel = OtelSpan::from_span(make_span("subscribe"), None);
+        assert_eq!(otel.span_kind, SpanKind::Consumer);
+        // No correlated publish → falls back to TLS parent from span data.
+        assert_eq!(otel.parent_span_id, Some("parent-1".to_string()));
     }
 
     #[test]

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
## Summary

- Rewrites `demo-agent` Parquet output to match the ROSQL OtelPostgres schema profile — ROSQL queries now work out of the box with `--backend parquet`
- Fixes `SINCE`/`UNTIL` time filters (new `timestamp` column as `Timestamp(Microsecond, UTC)`), `WHERE topic = '...'` (via `span_attributes` JSON), `WHERE robot_id = '...'` (via `resource_attributes` JSON), and `PATH DEVIATION`/`TRACE` queries (subscribe spans now carry the correlated publish span as `parent_span_id`)
- Both `otel_traces` and `otel_logs` schemas updated; ROS2-specific flat columns retained as extras after the core columns

## Key changes

**`demo-agent/src/export/parquet.rs`**
- New `traces_schema()`: 11 OtelPostgres-core columns first, then 17 ROS extras
- `timestamp`: `Timestamp(Microsecond, UTC)` (from `start_time_ns / 1000`)
- `service_name`: derived per-span as `/{namespace}/{node_name}`
- `span_attributes`: JSON with all `ros.*` keys
- `resource_attributes`: JSON with `robot.id` / `organization.id` (static per session)
- `duration`: renamed from `duration_ns`
- `parent_span_id`: non-nullable (empty string = no parent)
- New `logs_schema()`: `severity_text`, `log_attributes` JSON, non-nullable `trace_id`/`span_id`

**`demo-agent/src/pipeline/otel_builder.rs`**
- CONSUMER (subscribe) spans promote `correlated_publish_span_id` → `parent_span_id`

**`demo-agent/src/cli.rs` + `src/main.rs`**
- New `--robot-id` / `--organization-id` flags (also `ROBOTOPS_ROBOT_ID` / `ROBOTOPS_ORG_ID`)

## Test plan

- [ ] 45 unit + integration tests all pass (`just test` in `demo-agent/`)
- [ ] Smoke test: run demo-agent with `--robot-id r1`, query output with `rosql "FROM traces WHERE robot_id = 'r1'" --backend parquet`
- [ ] Verify `SINCE 5m` filter works against the new `timestamp` column
- [ ] Verify subscribe span `parent_span_id` matches its correlated publish span