### PR TITLE
feat(demo-agent): Docker-based e2e test rig for ROSQL query verification

### DIFF
--- a/.github/workflows/e2e-rosql.yml
+++ b/.github/workflows/e2e-rosql.yml
@@ -1,0 +1,48 @@
+name: E2E ROSQL
+
+on:
+  workflow_dispatch:
+    inputs:
+      settle_secs:
+        description: "Seconds to wait after publisher exits before SIGINT (default: 8)"
+        required: false
+        default: "8"
+      filter_mode:
+        description: "Set to 1 to run the topic-filter variant"
+        required: false
+        default: "0"
+      apt_repo_url:
+        description: "RobotOps APT repo URL (production or development)"
+        required: false
+        default: "https://apt.robotops.com"
+
+jobs:
+  e2e:
+    name: demo-agent → ROSQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run e2e test
+        env:
+          E2E_SETTLE_SECS: ${{ inputs.settle_secs }}
+          E2E_FILTER_MODE: ${{ inputs.filter_mode }}
+          APT_REPO_URL: ${{ inputs.apt_repo_url }}
+          E2E_KEEP_OUTPUT: "1"
+          E2E_OUTPUT_DIR: ${{ github.workspace }}/e2e-output
+        run: |
+          cd demo-agent
+          just e2e
+
+      - name: Upload Parquet output (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-parquet-output
+          path: e2e-output/
+          retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ conan.lock
 conaninfo.txt
 conanbuildinfo.*
 graph_info.json
+
+# E2E isolated colcon build dirs (non-ASan RelWithDebInfo build for e2e tests)
+e2e_build/
+e2e_install/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.2 (2026-04-19)
+-------------------
+
+* ``demo-agent``: add Docker-based e2e test rig (``demo-agent/tests/e2e/``) that verifies Parquet output is queryable by ROSQL (GH-46)
+
+  * Runs a turtlesim scenario (two processes under ``RMW_IMPLEMENTATION=rmw_robotops``) generating publish/subscribe, service, and action spans plus correlated log records
+  * Asserts producer, consumer, and server span kinds; cross-process correlation; logs↔traces linkage; and resource attribute population via ``rosql query``
+  * Topic-filter variant asserts ``ROBOTOPS_TRACE_TOPIC_FILTER`` suppresses matched topics
+  * Manual-only ``workflow_dispatch`` GitHub Actions workflow (``e2e-rosql.yml``); run locally with ``just e2e``
+
 0.9.1 (2026-04-19)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.3 (2026-04-19)
+-------------------
+
+* ``rmw_service.cpp``: fix ``EVENT_SERVICE_RESPONSE`` to reuse the span_id from ``EVENT_SERVICE_REQUEST`` (stored in thread-local context) so ``span_reconstructor`` can correlate them into a single SERVER span. Previously both events generated independent span_ids, yielding 0 SERVER spans in Parquet.
+* ``demo-agent/tests/e2e``: switch from two-container (publisher + agent) to single combined container; fixes DDS multicast failure in Docker Desktop for macOS. Resolves all 15 e2e ROSQL query assertions.
+* ``demo-agent/src/export/parquet.rs``: replace nested Tokio runtime with ``tokio::task::block_in_place`` to avoid panic on first Parquet flush.
+* ``demo-agent/src/subscribers``: fix QoS mismatch — trace and context subscribers now use ``best_effort()`` to match rmw_robotops publisher QoS.
+* ``demo-agent/tests/e2e/Dockerfile.query``: use ``ubuntu:24.04`` (GLIBC 2.39) instead of ``debian:bookworm-slim`` (GLIBC 2.36) to satisfy ``rosql`` GLIBC >= 2.38 requirement.
+
 0.9.2 (2026-04-19)
 -------------------
 

--- a/demo-agent/Justfile
+++ b/demo-agent/Justfile
@@ -52,6 +52,11 @@ ci: build-image
         {{IMAGE}} \
         bash -c "source /opt/ros/jazzy/setup.bash && just ci-inner"
 
+# Run the Docker-based e2e test: turtlesim scenario → Parquet → rosql assertions
+# Accepts the same env vars as tests/e2e/scripts/run.sh (E2E_SETTLE_SECS, etc.)
+e2e:
+    bash {{justfile_directory()}}/tests/e2e/scripts/run.sh
+
 # CI entrypoint — runs inside the container (called by GitHub Actions and `just ci`)
 ci-inner:
     #!/usr/bin/env bash

--- a/demo-agent/README.md
+++ b/demo-agent/README.md
@@ -279,6 +279,21 @@ docker run --rm \
 
 ---
 
+## E2E test rig
+
+An end-to-end Docker-based test verifies that `demo-agent` Parquet output is
+queryable by `rosql` against a live ROS2 turtlesim scenario. It runs manually
+(not part of regular PR CI):
+
+```bash
+just e2e
+```
+
+See [`tests/e2e/README.md`](tests/e2e/README.md) for full details, options, and
+troubleshooting.
+
+---
+
 ## Limitations
 
 - **Not for production.** No system metrics, TF monitoring, MCAP recording, offline buffering, or fleet management. For production use, see [robotops.com](https://robotops.com).

--- a/demo-agent/src/export/parquet.rs
+++ b/demo-agent/src/export/parquet.rs
@@ -108,7 +108,6 @@ pub struct ParquetExporter {
     bytes_written: u64,
     limit_bytes: u64,
     resource_attrs_json: String,
-    rt: tokio::runtime::Runtime,
 }
 
 impl ParquetExporter {
@@ -119,11 +118,6 @@ impl ParquetExporter {
         limit_mb: u64,
         resource_attrs_json: String,
     ) -> Result<Self> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| BridgeError::Storage(e.to_string()))?;
-
         let session_ts = Utc::now().format("%Y%m%d-%H%M%S").to_string();
         let session_path = format!("robotops_demo_agent/{}", session_ts);
 
@@ -149,7 +143,6 @@ impl ParquetExporter {
             bytes_written: 0,
             limit_bytes: limit_mb * 1024 * 1024,
             resource_attrs_json,
-            rt,
         })
     }
 
@@ -173,9 +166,11 @@ impl ParquetExporter {
             self.session_path, self.trace_part
         ));
 
-        self.rt
-            .block_on(self.store.put(&path, bytes.into()))
-            .map_err(BridgeError::from)?;
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(self.store.put(&path, bytes.into()))
+        })
+        .map_err(BridgeError::from)?;
 
         self.bytes_written += n_bytes;
         debug!(
@@ -203,9 +198,11 @@ impl ParquetExporter {
             self.session_path, self.log_part
         ));
 
-        self.rt
-            .block_on(self.store.put(&path, bytes.into()))
-            .map_err(BridgeError::from)?;
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(self.store.put(&path, bytes.into()))
+        })
+        .map_err(BridgeError::from)?;
 
         self.bytes_written += n_bytes;
         debug!(

--- a/demo-agent/src/export/parquet.rs
+++ b/demo-agent/src/export/parquet.rs
@@ -695,8 +695,8 @@ mod tests {
         assert!(bytes.len() > 100);
     }
 
-    #[test]
-    fn test_parquet_exporter_local() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_parquet_exporter_local() {
         let dir = tempfile::tempdir().unwrap();
         let mut exporter =
             ParquetExporter::new(dir.path().to_str().unwrap(), 10, 200, "{}".into()).unwrap();
@@ -712,8 +712,8 @@ mod tests {
         assert!(logs_dir.join("part-0001.parquet").exists());
     }
 
-    #[test]
-    fn test_storage_limit() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_storage_limit() {
         let dir = tempfile::tempdir().unwrap();
         // batch_size > 1 so auto-flush doesn't trigger; limit of 0 MB triggers on explicit flush
         let mut exporter =

--- a/demo-agent/src/export/parquet.rs
+++ b/demo-agent/src/export/parquet.rs
@@ -167,8 +167,7 @@ impl ParquetExporter {
         ));
 
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(self.store.put(&path, bytes.into()))
+            tokio::runtime::Handle::current().block_on(self.store.put(&path, bytes.into()))
         })
         .map_err(BridgeError::from)?;
 
@@ -199,8 +198,7 @@ impl ParquetExporter {
         ));
 
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(self.store.put(&path, bytes.into()))
+            tokio::runtime::Handle::current().block_on(self.store.put(&path, bytes.into()))
         })
         .map_err(BridgeError::from)?;
 

--- a/demo-agent/src/subscribers/context_subscriber.rs
+++ b/demo-agent/src/subscribers/context_subscriber.rs
@@ -27,7 +27,8 @@ pub fn spawn(
             .subscribe_raw(
                 TRACE_CONTEXT_TOPIC,
                 TRACE_CONTEXT_MSG_TYPE,
-                r2r::QosProfile::default(),
+                // context publisher uses BEST_EFFORT; subscriber must match
+                r2r::QosProfile::default().best_effort(),
             )
             .map_err(|e| anyhow::anyhow!("Failed to subscribe to {}: {}", TRACE_CONTEXT_TOPIC, e))?
     };

--- a/demo-agent/src/subscribers/trace_subscriber.rs
+++ b/demo-agent/src/subscribers/trace_subscriber.rs
@@ -38,7 +38,8 @@ pub fn spawn(
             .subscribe_raw(
                 TRACE_EVENTS_TOPIC,
                 TRACE_EVENTS_MSG_TYPE,
-                r2r::QosProfile::default(),
+                // trace publisher uses BEST_EFFORT; subscriber must match or DDS won't deliver
+                r2r::QosProfile::default().best_effort(),
             )
             .map_err(|e| anyhow::anyhow!("Failed to subscribe to {}: {}", TRACE_EVENTS_TOPIC, e))?
     };

--- a/demo-agent/tests/e2e/Dockerfile.agent
+++ b/demo-agent/tests/e2e/Dockerfile.agent
@@ -29,4 +29,4 @@ COPY --from=builder /build/target/release/robotops-demo-agent /usr/local/bin/rob
 COPY tests/e2e/scripts /tests/scripts
 RUN chmod +x /tests/scripts/*.sh
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["/tests/scripts/agent_entrypoint.sh"]

--- a/demo-agent/tests/e2e/Dockerfile.agent
+++ b/demo-agent/tests/e2e/Dockerfile.agent
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.4
+# Agent container: builds robotops-demo-agent binary, then creates a slim runtime.
+# Stage 1 reuses the CI image which already has Rust stable + ROS2 Jazzy + robotops-msgs.
+
+# ── Stage 1: compile ──────────────────────────────────────────────────────────
+FROM robotops-demo-agent:ci AS builder
+
+WORKDIR /build
+COPY . .
+RUN bash -c "source /opt/ros/jazzy/setup.bash && cargo build --release"
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+FROM ros:jazzy
+
+ARG APT_REPO_URL=https://apt.robotops.com
+
+RUN apt-get update && apt-get install -y curl ca-certificates gpg && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL ${APT_REPO_URL}/robotops-public-key.asc \
+        | gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] ${APT_REPO_URL} noble main" \
+        > /etc/apt/sources.list.d/robotops.list && \
+    apt-get update && \
+    apt-get install -y ros-jazzy-robotops-msgs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/robotops-demo-agent /usr/local/bin/robotops-demo-agent
+
+COPY tests/e2e/scripts /tests/scripts
+RUN chmod +x /tests/scripts/*.sh
+
+CMD ["/bin/bash"]

--- a/demo-agent/tests/e2e/Dockerfile.combined
+++ b/demo-agent/tests/e2e/Dockerfile.combined
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.4
+# Combined container: turtlesim publisher + robotops-demo-agent running together.
+# Both processes share loopback DDS so discovery is guaranteed regardless of
+# Docker Desktop networking limitations with inter-container multicast.
+#
+# Stage 1 compiles the demo-agent binary using the CI image (has Rust + ROS2).
+# Stage 2 extends rmw_robotops:dev (has turtlesim, rclpy, the colcon overlay
+# mechanism) and adds the compiled binary.
+
+# ── Stage 1: compile demo-agent ──────────────────────────────────────────────
+FROM robotops-demo-agent:ci AS agent-builder
+
+WORKDIR /build
+COPY demo-agent/ .
+RUN bash -c "source /opt/ros/jazzy/setup.bash && cargo build --release"
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+FROM rmw_robotops:dev
+
+RUN apt-get update && apt-get install -y \
+    ros-jazzy-turtlesim \
+    ros-jazzy-rclpy \
+    ros-jazzy-geometry-msgs \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=agent-builder /build/target/release/robotops-demo-agent /usr/local/bin/robotops-demo-agent
+
+COPY demo-agent/tests/e2e/scripts /tests/scripts
+RUN chmod +x /tests/scripts/*.sh
+
+ENTRYPOINT ["/tests/scripts/combined_entrypoint.sh"]

--- a/demo-agent/tests/e2e/Dockerfile.publisher
+++ b/demo-agent/tests/e2e/Dockerfile.publisher
@@ -7,12 +7,12 @@ FROM rmw_robotops:dev
 # Add turtlesim, rclpy, and Xvfb for headless GUI
 RUN apt-get update && apt-get install -y \
     ros-jazzy-turtlesim \
-    python3-rclpy \
-    python3-geometry-msgs \
+    ros-jazzy-rclpy \
+    ros-jazzy-geometry-msgs \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
 COPY demo-agent/tests/e2e/scripts /tests/scripts
 RUN chmod +x /tests/scripts/*.sh
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["/tests/scripts/publisher_entrypoint.sh"]

--- a/demo-agent/tests/e2e/Dockerfile.publisher
+++ b/demo-agent/tests/e2e/Dockerfile.publisher
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.4
+# Publisher container: ROS2 Jazzy + rmw_robotops (from colcon overlay) + turtlesim.
+# Extend the top-level dev stage which already has all rmw_robotops build deps,
+# the apt.robotops.com repo, and robotops-msgs.
+FROM rmw_robotops:dev
+
+# Add turtlesim, rclpy, and Xvfb for headless GUI
+RUN apt-get update && apt-get install -y \
+    ros-jazzy-turtlesim \
+    python3-rclpy \
+    python3-geometry-msgs \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tests/e2e/scripts /tests/scripts
+RUN chmod +x /tests/scripts/*.sh
+
+CMD ["/bin/bash"]

--- a/demo-agent/tests/e2e/Dockerfile.publisher
+++ b/demo-agent/tests/e2e/Dockerfile.publisher
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-COPY tests/e2e/scripts /tests/scripts
+COPY demo-agent/tests/e2e/scripts /tests/scripts
 RUN chmod +x /tests/scripts/*.sh
 
 CMD ["/bin/bash"]

--- a/demo-agent/tests/e2e/Dockerfile.query
+++ b/demo-agent/tests/e2e/Dockerfile.query
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.4
+# Query container: installs rosql CLI and Python for the assertion harness.
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    python3 \
+    python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install rosql via the official one-liner (Linux x86_64 and arm64)
+RUN curl -fsSL https://rosql.org/install.sh | sh
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+CMD ["/bin/bash"]

--- a/demo-agent/tests/e2e/Dockerfile.query
+++ b/demo-agent/tests/e2e/Dockerfile.query
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Query container: installs rosql CLI and Python for the assertion harness.
-FROM debian:bookworm-slim
+# rosql requires GLIBC >= 2.38; Ubuntu 24.04 ships with glibc 2.39
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/demo-agent/tests/e2e/README.md
+++ b/demo-agent/tests/e2e/README.md
@@ -1,0 +1,73 @@
+# demo-agent E2E test rig
+
+Verifies that a real ROS2 Jazzy robot scene traced through `rmw_robotops`
+produces Parquet output that `rosql` can actually query.
+
+## What it does
+
+1. Builds `rmw_robotops` from source into a Docker colcon overlay.
+2. Runs a **turtlesim scenario** (two processes under `RMW_IMPLEMENTATION=rmw_robotops`):
+   - `turtlesim_node` — publishes `/turtle1/pose`, handles services and actions.
+   - `drive_turtle.py` — calls `/spawn`, `/kill`, `/turtle1/set_pen` (service spans);
+     sends `/turtle1/rotate_absolute` goal (action traffic); publishes
+     `/turtle1/cmd_vel` and `/turtle2/cmd_vel` (producer spans);
+     subscribes to `/turtle1/pose` (consumer spans + log correlation).
+3. Captures the session with `robotops-demo-agent` into Parquet.
+4. Runs a `rosql` assertion harness over the output.
+
+## Running locally
+
+All execution happens inside Docker — no ROS2 installation required on the host.
+
+```bash
+cd <repo-root>/demo-agent
+just e2e
+```
+
+To keep the Parquet output for inspection after the run:
+
+```bash
+E2E_KEEP_OUTPUT=1 just e2e
+```
+
+To exercise the topic-filter variant (asserts `/turtle2` spans are absent):
+
+```bash
+E2E_FILTER_MODE=1 just e2e
+```
+
+## Options
+
+| Env var | Default | Description |
+|---|---|---|
+| `E2E_SETTLE_SECS` | `8` | Seconds to wait after publisher exits before SIGINT |
+| `E2E_ROS_DOMAIN_ID` | `42` | DDS domain ID (change if 42 conflicts on your machine) |
+| `E2E_FILTER_MODE` | `0` | Set to `1` to run the topic-filter variant |
+| `E2E_KEEP_OUTPUT` | `0` | Set to `1` to preserve the Parquet session dir |
+| `E2E_OUTPUT_DIR` | auto temp | Override the Parquet output directory |
+| `APT_REPO_URL` | `https://apt.robotops.com` | Override the RobotOps APT repo |
+
+## Query suite
+
+See `queries.yml` for the full list. Short summary:
+
+- **`>=1` (must return rows):** `traces_any`, `traces_producer`, `traces_consumer`,
+  `traces_server`, `traces_cmd_vel`, `traces_pose_subscriber`,
+  `traces_correlated_consumer`, `logs_any`, `logs_info_severity`,
+  `logs_correlated_to_traces`, `traces_resource_attrs_present`
+- **`>=0` (parse-only):** `traces_error_status`, `traces_action_related`,
+  `logs_warn_severity`
+- **`filter_mode_zero` (==0 when `E2E_FILTER_MODE=1`):** `traces_filtered_topic`
+
+## Troubleshooting
+
+**`No demo-agent session found`** — the agent container may have exited before
+writing. Increase `E2E_SETTLE_SECS` or check agent logs with
+`docker logs e2e_agent_run`.
+
+**DDS discovery failures** — if publisher and agent can't see each other, try
+changing `E2E_ROS_DOMAIN_ID` to avoid collision with other ROS2 nodes on the host.
+
+**rosql not found** — the query image installs rosql via
+`curl -fsSL https://rosql.org/install.sh | sh`. If the install fails (e.g., network
+timeout in CI), the error appears during `docker build` for `Dockerfile.query`.

--- a/demo-agent/tests/e2e/docker-compose.e2e.yml
+++ b/demo-agent/tests/e2e/docker-compose.e2e.yml
@@ -16,8 +16,8 @@ services:
     volumes:
       # rmw_robotops source (read-only, for entrypoint discovery)
       - ${E2E_REPO_ROOT:?set E2E_REPO_ROOT}:/workspace/src/rmw_robotops:ro
-      # colcon install cache populated by the top-level build service
-      - rmw_robotops_install_cache:/workspace/install:ro
+      # colcon install cache populated by the e2e-specific build (RelWithDebInfo, no ASan)
+      - rmw_robotops_e2e_install_cache:/workspace/install:ro
       # shared output for parquet files (not used by publisher, but harmless)
       - ${E2E_OUTPUT_DIR:?set E2E_OUTPUT_DIR}:/data
     environment:
@@ -53,6 +53,6 @@ services:
         --queries /tests/queries.yml
 
 volumes:
-  rmw_robotops_install_cache:
+  rmw_robotops_e2e_install_cache:
     external: true
-    name: rmw_robotops_install_cache
+    name: rmw_robotops_e2e_install_cache

--- a/demo-agent/tests/e2e/docker-compose.e2e.yml
+++ b/demo-agent/tests/e2e/docker-compose.e2e.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+# E2E test stack for demo-agent + ROSQL validation.
+#
+# Services:
+#   publisher  – turtlesim scenario under RMW_IMPLEMENTATION=rmw_robotops
+#   agent      – robotops-demo-agent writing Parquet to ${E2E_OUTPUT_DIR}
+#   query      – rosql assertion harness reading those Parquet files
+#
+# Usage: driven by tests/e2e/scripts/run.sh — do not start manually.
+
+services:
+  publisher:
+    image: rmw_robotops-e2e-publisher:latest
+    network_mode: host
+    volumes:
+      # rmw_robotops source (read-only, for entrypoint discovery)
+      - ${E2E_REPO_ROOT:?set E2E_REPO_ROOT}:/workspace/src/rmw_robotops:ro
+      # colcon install cache populated by the top-level build service
+      - rmw_robotops_install_cache:/workspace/install:ro
+      # shared output for parquet files (not used by publisher, but harmless)
+      - ${E2E_OUTPUT_DIR:?set E2E_OUTPUT_DIR}:/data
+    environment:
+      - ROS_DOMAIN_ID=${E2E_ROS_DOMAIN_ID:-42}
+      - RMW_IMPLEMENTATION=rmw_robotops
+      - ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
+      - ROBOTOPS_TRACING_ENABLED=true
+      - ROBOTOPS_ROBOT_ID=e2e-test-robot
+      - ROBOTOPS_ORG_ID=e2e-test-org
+      - ROBOTOPS_TRACE_TOPIC_FILTER=${ROBOTOPS_TRACE_TOPIC_FILTER:-}
+    entrypoint: ["/tests/scripts/publisher_entrypoint.sh"]
+
+  agent:
+    image: rmw_robotops-e2e-agent:latest
+    network_mode: host
+    volumes:
+      - ${E2E_OUTPUT_DIR:?set E2E_OUTPUT_DIR}:/data
+    environment:
+      - ROS_DOMAIN_ID=${E2E_ROS_DOMAIN_ID:-42}
+    entrypoint: ["/tests/scripts/agent_entrypoint.sh"]
+
+  query:
+    image: rmw_robotops-e2e-query:latest
+    volumes:
+      - ${E2E_OUTPUT_DIR:?set E2E_OUTPUT_DIR}:/data:ro
+      - ./scripts:/tests/scripts:ro
+      - ./queries.yml:/tests/queries.yml:ro
+    environment:
+      - E2E_FILTER_MODE=${E2E_FILTER_MODE:-0}
+    command: >
+      python3 /tests/scripts/assert_queries.py
+        --data-dir /data
+        --queries /tests/queries.yml
+
+volumes:
+  rmw_robotops_install_cache:
+    external: true
+    name: rmw_robotops_install_cache

--- a/demo-agent/tests/e2e/queries.yml
+++ b/demo-agent/tests/e2e/queries.yml
@@ -1,0 +1,87 @@
+# E2E query suite for demo-agent + ROSQL validation.
+#
+# expect values:
+#   ">=1"   — query must parse AND return at least one row
+#   ">=0"   — query must parse cleanly; empty result is acceptable
+#   "==0"   — query must parse AND return zero rows (used in filter-mode checks)
+
+queries:
+  # ── Core traces assertions ──────────────────────────────────────────────────
+  - name: traces_any
+    sql: "FROM traces SINCE 2h"
+    expect: ">=1"
+    description: "At least one trace span was captured"
+
+  - name: traces_producer
+    sql: "FROM traces WHERE span_kind = 'PRODUCER' SINCE 2h"
+    expect: ">=1"
+    description: "rmw_robotops emitted publish (PRODUCER) spans"
+
+  - name: traces_consumer
+    sql: "FROM traces WHERE span_kind = 'CONSUMER' SINCE 2h"
+    expect: ">=1"
+    description: "rmw_robotops emitted subscribe (CONSUMER) spans — cross-process correlation data point"
+
+  - name: traces_server
+    sql: "FROM traces WHERE span_kind = 'SERVER' SINCE 2h"
+    expect: ">=1"
+    description: "Service calls (/spawn, /kill) produced SERVER spans"
+
+  - name: traces_cmd_vel
+    sql: "FROM traces WHERE span_name LIKE 'publish /turtle1/cmd_vel%' SINCE 2h"
+    expect: ">=1"
+    description: "Velocity commands appear as named publish spans"
+
+  - name: traces_pose_subscriber
+    sql: "FROM traces WHERE span_name LIKE 'subscribe /turtle1/pose%' SINCE 2h"
+    expect: ">=1"
+    description: "/turtle1/pose subscribe spans prove cross-process correlation worked"
+
+  - name: traces_correlated_consumer
+    sql: "FROM traces WHERE span_kind = 'CONSUMER' AND parent_span_id != '' SINCE 2h"
+    expect: ">=1"
+    description: "At least one CONSUMER span has a parent set by cross-process correlation"
+
+  # ── Core logs assertions ────────────────────────────────────────────────────
+  - name: logs_any
+    sql: "FROM logs SINCE 2h"
+    expect: ">=1"
+    description: "At least one log record was captured from /rosout"
+
+  - name: logs_info_severity
+    sql: "FROM logs WHERE severity_text = 'INFO' SINCE 2h"
+    expect: ">=1"
+    description: "INFO-level logs were captured"
+
+  - name: logs_correlated_to_traces
+    sql: "FROM logs WHERE trace_id != '' SINCE 2h"
+    expect: ">=1"
+    description: "At least one log has a trace_id set (logs-to-traces correlation via TraceContextRegistry)"
+
+  # ── Resource attribute assertions ───────────────────────────────────────────
+  - name: traces_resource_attrs_present
+    sql: "FROM traces WHERE resource_attributes != '{}' SINCE 2h"
+    expect: ">=1"
+    description: "resource_attributes JSON is populated (robot.id / organization.id)"
+
+  # ── Parse-only checks (empty result is fine) ────────────────────────────────
+  - name: traces_error_status
+    sql: "FROM traces WHERE status_code = 'ERROR' SINCE 2h"
+    expect: ">=0"
+    description: "ERROR status filter parses correctly (no errors expected in normal run)"
+
+  - name: traces_action_related
+    sql: "FROM traces WHERE span_name LIKE '%rotate_absolute%' SINCE 2h"
+    expect: ">=0"
+    description: "rotate_absolute action spans parse; row count depends on span naming"
+
+  - name: logs_warn_severity
+    sql: "FROM logs WHERE severity_text = 'WARN' SINCE 2h"
+    expect: ">=0"
+    description: "WARN log filter parses correctly"
+
+  # ── Filter-mode check (==0 only when E2E_FILTER_MODE=1) ────────────────────
+  - name: traces_filtered_topic
+    sql: "FROM traces WHERE span_name LIKE 'publish /turtle2/cmd_vel%' SINCE 2h"
+    expect: "filter_mode_zero"
+    description: "When ROBOTOPS_TRACE_TOPIC_FILTER='^/turtle1/.*', /turtle2 spans must be absent"

--- a/demo-agent/tests/e2e/scripts/agent_entrypoint.sh
+++ b/demo-agent/tests/e2e/scripts/agent_entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Agent container entrypoint.
+# Runs robotops-demo-agent with settings tuned for the e2e test:
+#   - small batch + short flush interval so data is on disk promptly
+#   - short correlation window so the test doesn't need to wait 30 s
+#   - writes to /data (bind-mounted shared volume)
+set -euo pipefail
+
+source /opt/ros/jazzy/setup.bash
+
+echo "[agent] ROS_DOMAIN_ID=${ROS_DOMAIN_ID}"
+echo "[agent] Writing Parquet to /data ..."
+
+exec robotops-demo-agent \
+    --output /data \
+    --batch-size 50 \
+    --flush-interval-ms 1000 \
+    --correlation-window-secs 5 \
+    --robot-id "e2e-test-robot" \
+    --organization-id "e2e-test-org"

--- a/demo-agent/tests/e2e/scripts/agent_entrypoint.sh
+++ b/demo-agent/tests/e2e/scripts/agent_entrypoint.sh
@@ -4,8 +4,9 @@
 #   - small batch + short flush interval so data is on disk promptly
 #   - short correlation window so the test doesn't need to wait 30 s
 #   - writes to /data (bind-mounted shared volume)
-set -euo pipefail
+set -eo pipefail
 
+# ROS2 setup files reference unset variables internally; incompatible with set -u
 source /opt/ros/jazzy/setup.bash
 
 echo "[agent] ROS_DOMAIN_ID=${ROS_DOMAIN_ID}"

--- a/demo-agent/tests/e2e/scripts/assert_queries.py
+++ b/demo-agent/tests/e2e/scripts/assert_queries.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Run the ROSQL query suite against the demo-agent Parquet output.
+
+Usage:
+    python3 assert_queries.py --data-dir /data --queries /tests/queries.yml
+
+Exit 0 on full pass, 1 on any failure.
+"""
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+import yaml
+
+
+def find_session_dir(data_dir: str) -> str:
+    pattern = os.path.join(data_dir, "robotops_demo_agent", "*")
+    sessions = sorted(glob.glob(pattern))
+    if not sessions:
+        print(f"[ERROR] No demo-agent session found under {data_dir}/robotops_demo_agent/")
+        print(f"        Files present: {glob.glob(os.path.join(data_dir, '**'), recursive=True)[:20]}")
+        sys.exit(1)
+    return sessions[-1]
+
+
+def count_data_rows(output: str) -> int:
+    """Heuristically count data rows in rosql tabular output.
+
+    rosql prints a header line, a separator line, then data rows, then a footer
+    like '(N rows)'. We count lines that are not headers, separators, or footers.
+    """
+    lines = output.strip().splitlines()
+    data_rows = 0
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Skip separator lines (all dashes/pluses)
+        if all(c in "-+| " for c in stripped):
+            continue
+        # Skip footer lines like "(5 rows)" or "(0 rows)"
+        if stripped.startswith("(") and stripped.endswith(")"):
+            continue
+        # Skip header line (first non-separator line is the header)
+        if data_rows == -1:
+            data_rows = 0
+            continue
+        data_rows += 1
+    return max(0, data_rows - 1)  # subtract the header row
+
+
+def run_query(sql: str, session_dir: str) -> tuple[int, str, str]:
+    """Run a rosql query and return (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        ["rosql", "query", sql, "--backend", "parquet", "--url", session_dir],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--queries", required=True)
+    args = parser.parse_args()
+
+    filter_mode = os.environ.get("E2E_FILTER_MODE", "0") == "1"
+
+    with open(args.queries) as f:
+        suite = yaml.safe_load(f)
+
+    session_dir = find_session_dir(args.data_dir)
+    print(f"[assert] Session: {session_dir}")
+    print(f"[assert] Filter mode: {filter_mode}")
+    print()
+
+    passes = 0
+    failures = 0
+    skipped = 0
+
+    for entry in suite["queries"]:
+        name = entry["name"]
+        sql = entry["sql"]
+        expect = entry["expect"]
+        desc = entry.get("description", "")
+
+        # filter_mode_zero queries only assert ==0 rows when E2E_FILTER_MODE=1;
+        # otherwise they are treated as >=0 (parse-only)
+        effective_expect = expect
+        if expect == "filter_mode_zero":
+            effective_expect = "==0" if filter_mode else ">=0"
+
+        try:
+            rc, stdout, stderr = run_query(sql, session_dir)
+        except subprocess.TimeoutExpired:
+            print(f"[FAIL] {name}: query timed out after 30s")
+            print(f"       sql: {sql}")
+            failures += 1
+            continue
+
+        if rc != 0:
+            print(f"[FAIL] {name}: rosql exited {rc}")
+            print(f"       sql:    {sql}")
+            print(f"       stderr: {stderr.strip()}")
+            failures += 1
+            continue
+
+        rows = count_data_rows(stdout)
+
+        if effective_expect == ">=1" and rows < 1:
+            print(f"[FAIL] {name}: expected >=1 rows, got {rows}")
+            print(f"       sql:    {sql}")
+            print(f"       desc:   {desc}")
+            print(f"       output: {stdout.strip()[:300]}")
+            failures += 1
+        elif effective_expect == "==0" and rows != 0:
+            print(f"[FAIL] {name}: expected ==0 rows (filter mode), got {rows}")
+            print(f"       sql: {sql}")
+            failures += 1
+        else:
+            status = "PASS"
+            print(f"[{status}] {name:<40} rows={rows:>4}   expect={effective_expect}   {desc}")
+            passes += 1
+
+    print()
+    print(f"Results: {passes} passed, {failures} failed, {skipped} skipped")
+
+    if failures > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-agent/tests/e2e/scripts/assert_queries.py
+++ b/demo-agent/tests/e2e/scripts/assert_queries.py
@@ -13,6 +13,7 @@ import glob
 import os
 import subprocess
 import sys
+
 import yaml
 
 
@@ -21,7 +22,8 @@ def find_session_dir(data_dir: str) -> str:
     sessions = sorted(glob.glob(pattern))
     if not sessions:
         print(f'[ERROR] No demo-agent session found under {data_dir}/robotops_demo_agent/')
-        print(f'        Files present: {glob.glob(os.path.join(data_dir, "**"), recursive=True)[:20]}')
+        found = glob.glob(os.path.join(data_dir, '**'), recursive=True)[:20]
+        print(f'        Files present: {found}')
         sys.exit(1)
     return sessions[-1]
 

--- a/demo-agent/tests/e2e/scripts/assert_queries.py
+++ b/demo-agent/tests/e2e/scripts/assert_queries.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Run the ROSQL query suite against the demo-agent Parquet output.
+"""
+Run the ROSQL query suite against the demo-agent Parquet output.
 
 Usage:
     python3 assert_queries.py --data-dir /data --queries /tests/queries.yml
@@ -16,17 +17,18 @@ import yaml
 
 
 def find_session_dir(data_dir: str) -> str:
-    pattern = os.path.join(data_dir, "robotops_demo_agent", "*")
+    pattern = os.path.join(data_dir, 'robotops_demo_agent', '*')
     sessions = sorted(glob.glob(pattern))
     if not sessions:
-        print(f"[ERROR] No demo-agent session found under {data_dir}/robotops_demo_agent/")
-        print(f"        Files present: {glob.glob(os.path.join(data_dir, '**'), recursive=True)[:20]}")
+        print(f'[ERROR] No demo-agent session found under {data_dir}/robotops_demo_agent/')
+        print(f'        Files present: {glob.glob(os.path.join(data_dir, "**"), recursive=True)[:20]}')
         sys.exit(1)
     return sessions[-1]
 
 
 def count_data_rows(output: str) -> int:
-    """Heuristically count data rows in rosql tabular output.
+    """
+    Heuristically count data rows in rosql tabular output.
 
     rosql prints a header line, a separator line, then data rows, then a footer
     like '(N rows)'. We count lines that are not headers, separators, or footers.
@@ -38,10 +40,10 @@ def count_data_rows(output: str) -> int:
         if not stripped:
             continue
         # Skip separator lines (all dashes/pluses)
-        if all(c in "-+| " for c in stripped):
+        if all(c in '-+| ' for c in stripped):
             continue
         # Skip footer lines like "(5 rows)" or "(0 rows)"
-        if stripped.startswith("(") and stripped.endswith(")"):
+        if stripped.startswith('(') and stripped.endswith(')'):
             continue
         # Skip header line (first non-separator line is the header)
         if data_rows == -1:
@@ -54,7 +56,7 @@ def count_data_rows(output: str) -> int:
 def run_query(sql: str, session_dir: str) -> tuple[int, str, str]:
     """Run a rosql query and return (returncode, stdout, stderr)."""
     result = subprocess.run(
-        ["rosql", "query", sql, "--backend", "parquet", "--url", session_dir],
+        ['rosql', 'query', sql, '--backend', 'parquet', '--url', session_dir],
         capture_output=True,
         text=True,
         timeout=30,
@@ -64,74 +66,74 @@ def run_query(sql: str, session_dir: str) -> tuple[int, str, str]:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-dir", required=True)
-    parser.add_argument("--queries", required=True)
+    parser.add_argument('--data-dir', required=True)
+    parser.add_argument('--queries', required=True)
     args = parser.parse_args()
 
-    filter_mode = os.environ.get("E2E_FILTER_MODE", "0") == "1"
+    filter_mode = os.environ.get('E2E_FILTER_MODE', '0') == '1'
 
     with open(args.queries) as f:
         suite = yaml.safe_load(f)
 
     session_dir = find_session_dir(args.data_dir)
-    print(f"[assert] Session: {session_dir}")
-    print(f"[assert] Filter mode: {filter_mode}")
+    print(f'[assert] Session: {session_dir}')
+    print(f'[assert] Filter mode: {filter_mode}')
     print()
 
     passes = 0
     failures = 0
     skipped = 0
 
-    for entry in suite["queries"]:
-        name = entry["name"]
-        sql = entry["sql"]
-        expect = entry["expect"]
-        desc = entry.get("description", "")
+    for entry in suite['queries']:
+        name = entry['name']
+        sql = entry['sql']
+        expect = entry['expect']
+        desc = entry.get('description', '')
 
         # filter_mode_zero queries only assert ==0 rows when E2E_FILTER_MODE=1;
         # otherwise they are treated as >=0 (parse-only)
         effective_expect = expect
-        if expect == "filter_mode_zero":
-            effective_expect = "==0" if filter_mode else ">=0"
+        if expect == 'filter_mode_zero':
+            effective_expect = '==0' if filter_mode else '>=0'
 
         try:
             rc, stdout, stderr = run_query(sql, session_dir)
         except subprocess.TimeoutExpired:
-            print(f"[FAIL] {name}: query timed out after 30s")
-            print(f"       sql: {sql}")
+            print(f'[FAIL] {name}: query timed out after 30s')
+            print(f'       sql: {sql}')
             failures += 1
             continue
 
         if rc != 0:
-            print(f"[FAIL] {name}: rosql exited {rc}")
-            print(f"       sql:    {sql}")
-            print(f"       stderr: {stderr.strip()}")
+            print(f'[FAIL] {name}: rosql exited {rc}')
+            print(f'       sql:    {sql}')
+            print(f'       stderr: {stderr.strip()}')
             failures += 1
             continue
 
         rows = count_data_rows(stdout)
 
-        if effective_expect == ">=1" and rows < 1:
-            print(f"[FAIL] {name}: expected >=1 rows, got {rows}")
-            print(f"       sql:    {sql}")
-            print(f"       desc:   {desc}")
-            print(f"       output: {stdout.strip()[:300]}")
+        if effective_expect == '>=1' and rows < 1:
+            print(f'[FAIL] {name}: expected >=1 rows, got {rows}')
+            print(f'       sql:    {sql}')
+            print(f'       desc:   {desc}')
+            print(f'       output: {stdout.strip()[:300]}')
             failures += 1
-        elif effective_expect == "==0" and rows != 0:
-            print(f"[FAIL] {name}: expected ==0 rows (filter mode), got {rows}")
-            print(f"       sql: {sql}")
+        elif effective_expect == '==0' and rows != 0:
+            print(f'[FAIL] {name}: expected ==0 rows (filter mode), got {rows}')
+            print(f'       sql: {sql}')
             failures += 1
         else:
-            status = "PASS"
-            print(f"[{status}] {name:<40} rows={rows:>4}   expect={effective_expect}   {desc}")
+            status = 'PASS'
+            print(f'[{status}] {name:<40} rows={rows:>4}   expect={effective_expect}   {desc}')
             passes += 1
 
     print()
-    print(f"Results: {passes} passed, {failures} failed, {skipped} skipped")
+    print(f'Results: {passes} passed, {failures} failed, {skipped} skipped')
 
     if failures > 0:
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/demo-agent/tests/e2e/scripts/combined_entrypoint.sh
+++ b/demo-agent/tests/e2e/scripts/combined_entrypoint.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Combined container entrypoint: runs turtlesim + drive_turtle.py (under
+# RMW_IMPLEMENTATION=rmw_robotops) and robotops-demo-agent (stock FastDDS)
+# in the same container so they communicate via loopback DDS — no multicast
+# discovery needed, works reliably on Docker Desktop for macOS.
+set -eo pipefail
+
+# ROS2 setup.bash references unset variables; incompatible with set -u
+source /opt/ros/jazzy/setup.bash
+# e2e_install is the dedicated RelWithDebInfo overlay, isolated from the
+# ASan-compiled dev/test build that lives in install/.
+source /workspace/src/rmw_robotops/e2e_install/local_setup.bash
+
+SETTLE_SECS="${E2E_SETTLE_SECS:-8}"
+
+echo "[combined] RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
+echo "[combined] ROBOTOPS_UNDERLYING_RMW=${ROBOTOPS_UNDERLYING_RMW}"
+echo "[combined] ROS_DOMAIN_ID=${ROS_DOMAIN_ID}"
+[ -n "${ROBOTOPS_TRACE_TOPIC_FILTER:-}" ] && \
+    echo "[combined] ROBOTOPS_TRACE_TOPIC_FILTER=${ROBOTOPS_TRACE_TOPIC_FILTER}"
+
+# ── Xvfb ─────────────────────────────────────────────────────────────────────
+Xvfb :99 -screen 0 800x600x24 &
+XVFB_PID=$!
+export DISPLAY=:99
+sleep 1
+
+# ── turtlesim (under rmw_robotops so its pub/sub traffic is traced) ───────────
+ros2 run turtlesim turtlesim_node &
+TURTLESIM_PID=$!
+sleep 3
+
+# ── demo-agent (stock FastDDS — unset rmw_robotops vars to avoid trace loop) ──
+env -u RMW_IMPLEMENTATION \
+    -u ROBOTOPS_UNDERLYING_RMW \
+    -u ROBOTOPS_TRACING_ENABLED \
+    robotops-demo-agent \
+        --output /data \
+        --batch-size 50 \
+        --flush-interval-ms 1000 \
+        --correlation-window-secs 5 \
+        --robot-id "e2e-test-robot" \
+        --organization-id "e2e-test-org" &
+AGENT_PID=$!
+
+# Give the agent a moment to subscribe before the scenario starts publishing
+sleep 2
+
+# ── drive the turtlesim scenario ──────────────────────────────────────────────
+echo "[combined] Running drive_turtle.py ..."
+python3 /tests/scripts/drive_turtle.py
+
+echo "[combined] Scenario finished — settling ${SETTLE_SECS}s for final events..."
+sleep "$SETTLE_SECS"
+
+# ── flush agent ───────────────────────────────────────────────────────────────
+echo "[combined] Sending SIGINT to agent (final Parquet flush)..."
+kill -INT "$AGENT_PID" 2>/dev/null || true
+wait "$AGENT_PID" 2>/dev/null || true
+
+echo "[combined] Agent flushed. Done."
+
+# ── cleanup ───────────────────────────────────────────────────────────────────
+kill "$TURTLESIM_PID" 2>/dev/null || true
+wait "$TURTLESIM_PID" 2>/dev/null || true
+kill "$XVFB_PID" 2>/dev/null || true

--- a/demo-agent/tests/e2e/scripts/drive_turtle.py
+++ b/demo-agent/tests/e2e/scripts/drive_turtle.py
@@ -14,11 +14,10 @@ import math
 import sys
 import time
 
+from geometry_msgs.msg import Twist
 import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
-
-from geometry_msgs.msg import Twist
 from turtlesim.action import RotateAbsolute
 from turtlesim.msg import Pose
 from turtlesim.srv import Kill, SetPen, Spawn

--- a/demo-agent/tests/e2e/scripts/drive_turtle.py
+++ b/demo-agent/tests/e2e/scripts/drive_turtle.py
@@ -73,7 +73,6 @@ class TurtleDriver(Node):
     def _publish_square(self, side_duration=2.0, turn_duration=0.75):
         """Drive a square: four sides + four turns."""
         self.get_logger().info("Driving square path on /turtle1/cmd_vel...")
-        rate = self.create_rate(20)
         for _ in range(4):
             # Straight
             deadline = time.monotonic() + side_duration
@@ -82,7 +81,7 @@ class TurtleDriver(Node):
                 t.linear.x = LINEAR_SPEED
                 self._vel1.publish(t)
                 rclpy.spin_once(self, timeout_sec=0.0)
-                rate.sleep()
+                time.sleep(0.05)
             # Turn
             deadline = time.monotonic() + turn_duration
             while time.monotonic() < deadline:
@@ -90,14 +89,13 @@ class TurtleDriver(Node):
                 t.angular.z = ANGULAR_SPEED
                 self._vel1.publish(t)
                 rclpy.spin_once(self, timeout_sec=0.0)
-                rate.sleep()
+                time.sleep(0.05)
 
     def _publish_circle(self, duration=4.0):
         """Drive a circle on /turtle2/cmd_vel (if turtle2 exists)."""
         if self._vel2_pub is None:
             return
         self.get_logger().info("Driving circle path on /turtle2/cmd_vel...")
-        rate = self.create_rate(20)
         deadline = time.monotonic() + duration
         while time.monotonic() < deadline:
             t = Twist()
@@ -105,7 +103,7 @@ class TurtleDriver(Node):
             t.angular.z = 1.0
             self._vel2_pub.publish(t)
             rclpy.spin_once(self, timeout_sec=0.0)
-            rate.sleep()
+            time.sleep(0.05)
 
     def _do_rotate_absolute(self, theta: float):
         """Send a RotateAbsolute action goal and wait for result."""

--- a/demo-agent/tests/e2e/scripts/drive_turtle.py
+++ b/demo-agent/tests/e2e/scripts/drive_turtle.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Scripted turtlesim scenario for e2e tracing verification.
+
+Exercises:
+  - PRODUCER spans: publishing /turtle1/cmd_vel, /turtle2/cmd_vel
+  - CONSUMER spans: subscribing to /turtle1/pose (cross-process correlation)
+  - SERVER spans:   /spawn, /kill, /turtle1/set_pen service calls
+  - Action spans:   /turtle1/rotate_absolute (underlying pub/sub + service traffic)
+  - Log correlation: logger.info() from pose callback so TraceContextRegistry fires
+"""
+
+import math
+import sys
+import time
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from geometry_msgs.msg import Twist
+from turtlesim.action import RotateAbsolute
+from turtlesim.msg import Pose
+from turtlesim.srv import Kill, SetPen, Spawn
+
+
+DRIVE_SECONDS = 20.0
+LINEAR_SPEED = 1.5
+ANGULAR_SPEED = 1.5
+
+
+class TurtleDriver(Node):
+    def __init__(self):
+        super().__init__("turtle_driver")
+
+        self._vel1 = self.create_publisher(Twist, "/turtle1/cmd_vel", 10)
+        self._vel2_pub = None  # created after /spawn
+
+        self._pose_count = 0
+        self._pose_sub = self.create_subscription(
+            Pose, "/turtle1/pose", self._on_pose, 10
+        )
+
+        self._spawn = self.create_client(Spawn, "/spawn")
+        self._kill = self.create_client(Kill, "/kill")
+        self._set_pen = self.create_client(SetPen, "/turtle1/set_pen")
+        self._rotate = ActionClient(self, RotateAbsolute, "/turtle1/rotate_absolute")
+
+    # ── callbacks ────────────────────────────────────────────────────────────
+
+    def _on_pose(self, msg: Pose):
+        # Emit a logger call while inside a subscribe callback so the active
+        # trace context (set by rmw_robotops) is captured in TraceContextRegistry
+        # and stamped onto the resulting /rosout log record.
+        self._pose_count += 1
+        if self._pose_count % 20 == 0:
+            self.get_logger().info(
+                f"pose: x={msg.x:.2f} y={msg.y:.2f} θ={msg.theta:.2f} "
+                f"[sample #{self._pose_count}]"
+            )
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def _wait_for_service(self, client, timeout=10.0):
+        if not client.wait_for_service(timeout_sec=timeout):
+            self.get_logger().error(f"Service {client.srv_name} not available")
+            sys.exit(1)
+
+    def _call_service(self, client, request):
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
+        return future.result()
+
+    def _publish_square(self, side_duration=2.0, turn_duration=0.75):
+        """Drive a square: four sides + four turns."""
+        self.get_logger().info("Driving square path on /turtle1/cmd_vel...")
+        rate = self.create_rate(20)
+        for _ in range(4):
+            # Straight
+            deadline = time.monotonic() + side_duration
+            while time.monotonic() < deadline:
+                t = Twist()
+                t.linear.x = LINEAR_SPEED
+                self._vel1.publish(t)
+                rclpy.spin_once(self, timeout_sec=0.0)
+                rate.sleep()
+            # Turn
+            deadline = time.monotonic() + turn_duration
+            while time.monotonic() < deadline:
+                t = Twist()
+                t.angular.z = ANGULAR_SPEED
+                self._vel1.publish(t)
+                rclpy.spin_once(self, timeout_sec=0.0)
+                rate.sleep()
+
+    def _publish_circle(self, duration=4.0):
+        """Drive a circle on /turtle2/cmd_vel (if turtle2 exists)."""
+        if self._vel2_pub is None:
+            return
+        self.get_logger().info("Driving circle path on /turtle2/cmd_vel...")
+        rate = self.create_rate(20)
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline:
+            t = Twist()
+            t.linear.x = 1.0
+            t.angular.z = 1.0
+            self._vel2_pub.publish(t)
+            rclpy.spin_once(self, timeout_sec=0.0)
+            rate.sleep()
+
+    def _do_rotate_absolute(self, theta: float):
+        """Send a RotateAbsolute action goal and wait for result."""
+        self.get_logger().info(f"Sending rotate_absolute goal: theta={theta:.2f}")
+        if not self._rotate.wait_for_server(timeout_sec=10.0):
+            self.get_logger().warn("rotate_absolute action server not available, skipping")
+            return
+        goal = RotateAbsolute.Goal()
+        goal.theta = theta
+        future = self._rotate.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
+        goal_handle = future.result()
+        if goal_handle is None or not goal_handle.accepted:
+            self.get_logger().warn("rotate_absolute goal rejected")
+            return
+        result_future = goal_handle.get_result_async()
+        rclpy.spin_until_future_complete(self, result_future, timeout_sec=15.0)
+        self.get_logger().info("rotate_absolute completed")
+
+    # ── main scenario ────────────────────────────────────────────────────────
+
+    def run_scenario(self):
+        self.get_logger().info("=== turtle_driver: starting scenario ===")
+
+        # 1. Wait for services
+        for client in [self._spawn, self._kill, self._set_pen]:
+            self._wait_for_service(client)
+
+        # 2. Set pen color (SERVER span)
+        self.get_logger().info("Calling /turtle1/set_pen (SERVICE span)...")
+        self._call_service(self._set_pen, SetPen.Request(r=200, g=50, b=50, width=3, off=0))
+
+        # 3. Spawn turtle2 (SERVER span)
+        self.get_logger().info("Calling /spawn for turtle2 (SERVICE span)...")
+        self._call_service(
+            self._spawn,
+            Spawn.Request(x=3.0, y=5.0, theta=0.0, name="turtle2"),
+        )
+        self._vel2_pub = self.create_publisher(Twist, "/turtle2/cmd_vel", 10)
+
+        # 4. Drive a square on turtle1 (PRODUCER spans)
+        self._publish_square()
+
+        # 5. Rotate absolute action on turtle1 (action traffic)
+        self._do_rotate_absolute(math.pi / 2)
+
+        # 6. Drive circle on turtle2 (PRODUCER spans on /turtle2/cmd_vel)
+        self._publish_circle()
+
+        # 7. Kill turtle2 (SERVER span)
+        self.get_logger().info("Calling /kill for turtle2 (SERVICE span)...")
+        self._call_service(self._kill, Kill.Request(name="turtle2"))
+
+        self.get_logger().info(
+            f"=== scenario complete — captured {self._pose_count} pose samples ==="
+        )
+
+
+def main():
+    rclpy.init()
+    node = TurtleDriver()
+
+    # Let subscriptions settle before driving
+    for _ in range(20):
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    node.run_scenario()
+
+    # Keep spinning briefly so final pose callbacks and /rosout messages flush
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-agent/tests/e2e/scripts/drive_turtle.py
+++ b/demo-agent/tests/e2e/scripts/drive_turtle.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Scripted turtlesim scenario for e2e tracing verification.
+"""
+Scripted turtlesim scenario for e2e tracing verification.
 
 Exercises:
   - PRODUCER spans: publishing /turtle1/cmd_vel, /turtle2/cmd_vel
@@ -30,20 +31,20 @@ ANGULAR_SPEED = 1.5
 
 class TurtleDriver(Node):
     def __init__(self):
-        super().__init__("turtle_driver")
+        super().__init__('turtle_driver')
 
-        self._vel1 = self.create_publisher(Twist, "/turtle1/cmd_vel", 10)
+        self._vel1 = self.create_publisher(Twist, '/turtle1/cmd_vel', 10)
         self._vel2_pub = None  # created after /spawn
 
         self._pose_count = 0
         self._pose_sub = self.create_subscription(
-            Pose, "/turtle1/pose", self._on_pose, 10
+            Pose, '/turtle1/pose', self._on_pose, 10
         )
 
-        self._spawn = self.create_client(Spawn, "/spawn")
-        self._kill = self.create_client(Kill, "/kill")
-        self._set_pen = self.create_client(SetPen, "/turtle1/set_pen")
-        self._rotate = ActionClient(self, RotateAbsolute, "/turtle1/rotate_absolute")
+        self._spawn = self.create_client(Spawn, '/spawn')
+        self._kill = self.create_client(Kill, '/kill')
+        self._set_pen = self.create_client(SetPen, '/turtle1/set_pen')
+        self._rotate = ActionClient(self, RotateAbsolute, '/turtle1/rotate_absolute')
 
     # ── callbacks ────────────────────────────────────────────────────────────
 
@@ -54,15 +55,15 @@ class TurtleDriver(Node):
         self._pose_count += 1
         if self._pose_count % 20 == 0:
             self.get_logger().info(
-                f"pose: x={msg.x:.2f} y={msg.y:.2f} θ={msg.theta:.2f} "
-                f"[sample #{self._pose_count}]"
+                f'pose: x={msg.x:.2f} y={msg.y:.2f} θ={msg.theta:.2f} '
+                f'[sample #{self._pose_count}]'
             )
 
     # ── helpers ───────────────────────────────────────────────────────────────
 
     def _wait_for_service(self, client, timeout=10.0):
         if not client.wait_for_service(timeout_sec=timeout):
-            self.get_logger().error(f"Service {client.srv_name} not available")
+            self.get_logger().error(f'Service {client.srv_name} not available')
             sys.exit(1)
 
     def _call_service(self, client, request):
@@ -72,7 +73,7 @@ class TurtleDriver(Node):
 
     def _publish_square(self, side_duration=2.0, turn_duration=0.75):
         """Drive a square: four sides + four turns."""
-        self.get_logger().info("Driving square path on /turtle1/cmd_vel...")
+        self.get_logger().info('Driving square path on /turtle1/cmd_vel...')
         for _ in range(4):
             # Straight
             deadline = time.monotonic() + side_duration
@@ -95,7 +96,7 @@ class TurtleDriver(Node):
         """Drive a circle on /turtle2/cmd_vel (if turtle2 exists)."""
         if self._vel2_pub is None:
             return
-        self.get_logger().info("Driving circle path on /turtle2/cmd_vel...")
+        self.get_logger().info('Driving circle path on /turtle2/cmd_vel...')
         deadline = time.monotonic() + duration
         while time.monotonic() < deadline:
             t = Twist()
@@ -107,9 +108,9 @@ class TurtleDriver(Node):
 
     def _do_rotate_absolute(self, theta: float):
         """Send a RotateAbsolute action goal and wait for result."""
-        self.get_logger().info(f"Sending rotate_absolute goal: theta={theta:.2f}")
+        self.get_logger().info(f'Sending rotate_absolute goal: theta={theta:.2f}')
         if not self._rotate.wait_for_server(timeout_sec=10.0):
-            self.get_logger().warn("rotate_absolute action server not available, skipping")
+            self.get_logger().warn('rotate_absolute action server not available, skipping')
             return
         goal = RotateAbsolute.Goal()
         goal.theta = theta
@@ -117,32 +118,32 @@ class TurtleDriver(Node):
         rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
         goal_handle = future.result()
         if goal_handle is None or not goal_handle.accepted:
-            self.get_logger().warn("rotate_absolute goal rejected")
+            self.get_logger().warn('rotate_absolute goal rejected')
             return
         result_future = goal_handle.get_result_async()
         rclpy.spin_until_future_complete(self, result_future, timeout_sec=15.0)
-        self.get_logger().info("rotate_absolute completed")
+        self.get_logger().info('rotate_absolute completed')
 
     # ── main scenario ────────────────────────────────────────────────────────
 
     def run_scenario(self):
-        self.get_logger().info("=== turtle_driver: starting scenario ===")
+        self.get_logger().info('=== turtle_driver: starting scenario ===')
 
         # 1. Wait for services
         for client in [self._spawn, self._kill, self._set_pen]:
             self._wait_for_service(client)
 
         # 2. Set pen color (SERVER span)
-        self.get_logger().info("Calling /turtle1/set_pen (SERVICE span)...")
+        self.get_logger().info('Calling /turtle1/set_pen (SERVICE span)...')
         self._call_service(self._set_pen, SetPen.Request(r=200, g=50, b=50, width=3, off=0))
 
         # 3. Spawn turtle2 (SERVER span)
-        self.get_logger().info("Calling /spawn for turtle2 (SERVICE span)...")
+        self.get_logger().info('Calling /spawn for turtle2 (SERVICE span)...')
         self._call_service(
             self._spawn,
-            Spawn.Request(x=3.0, y=5.0, theta=0.0, name="turtle2"),
+            Spawn.Request(x=3.0, y=5.0, theta=0.0, name='turtle2'),
         )
-        self._vel2_pub = self.create_publisher(Twist, "/turtle2/cmd_vel", 10)
+        self._vel2_pub = self.create_publisher(Twist, '/turtle2/cmd_vel', 10)
 
         # 4. Drive a square on turtle1 (PRODUCER spans)
         self._publish_square()
@@ -154,11 +155,11 @@ class TurtleDriver(Node):
         self._publish_circle()
 
         # 7. Kill turtle2 (SERVER span)
-        self.get_logger().info("Calling /kill for turtle2 (SERVICE span)...")
-        self._call_service(self._kill, Kill.Request(name="turtle2"))
+        self.get_logger().info('Calling /kill for turtle2 (SERVICE span)...')
+        self._call_service(self._kill, Kill.Request(name='turtle2'))
 
         self.get_logger().info(
-            f"=== scenario complete — captured {self._pose_count} pose samples ==="
+            f'=== scenario complete — captured {self._pose_count} pose samples ==='
         )
 
 
@@ -181,5 +182,5 @@ def main():
     rclpy.shutdown()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/demo-agent/tests/e2e/scripts/publisher_entrypoint.sh
+++ b/demo-agent/tests/e2e/scripts/publisher_entrypoint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Publisher container entrypoint.
+# Sources the rmw_robotops colcon overlay so RMW_IMPLEMENTATION=rmw_robotops resolves,
+# then runs turtlesim_node (headless via Xvfb) + the scripted drive scenario.
+set -euo pipefail
+
+source /opt/ros/jazzy/setup.bash
+source /workspace/install/setup.bash
+
+echo "[publisher] RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
+echo "[publisher] ROBOTOPS_UNDERLYING_RMW=${ROBOTOPS_UNDERLYING_RMW}"
+echo "[publisher] ROS_DOMAIN_ID=${ROS_DOMAIN_ID}"
+[ -n "${ROBOTOPS_TRACE_TOPIC_FILTER:-}" ] && \
+    echo "[publisher] ROBOTOPS_TRACE_TOPIC_FILTER=${ROBOTOPS_TRACE_TOPIC_FILTER}"
+
+# Start a virtual framebuffer so turtlesim_node can create its window
+Xvfb :99 -screen 0 800x600x24 &
+XVFB_PID=$!
+export DISPLAY=:99
+
+# Give Xvfb a moment to initialise
+sleep 1
+
+# Start turtlesim in the background (both this process and turtlesim_node inherit
+# RMW_IMPLEMENTATION so rmw_robotops traces both sides of the pub/sub)
+ros2 run turtlesim turtlesim_node &
+TURTLESIM_PID=$!
+
+# Wait for turtlesim to advertise its services before driving
+sleep 3
+
+echo "[publisher] Running drive_turtle.py ..."
+python3 /tests/scripts/drive_turtle.py
+
+echo "[publisher] Scenario finished — shutting down"
+kill "$TURTLESIM_PID" 2>/dev/null || true
+wait "$TURTLESIM_PID" 2>/dev/null || true
+kill "$XVFB_PID" 2>/dev/null || true

--- a/demo-agent/tests/e2e/scripts/publisher_entrypoint.sh
+++ b/demo-agent/tests/e2e/scripts/publisher_entrypoint.sh
@@ -2,10 +2,13 @@
 # Publisher container entrypoint.
 # Sources the rmw_robotops colcon overlay so RMW_IMPLEMENTATION=rmw_robotops resolves,
 # then runs turtlesim_node (headless via Xvfb) + the scripted drive scenario.
-set -euo pipefail
+set -eo pipefail
 
+# ROS2 setup files reference unset variables internally; incompatible with set -u
 source /opt/ros/jazzy/setup.bash
-source /workspace/install/setup.bash
+# Colcon installs relative to its CWD (/workspace/src/rmw_robotops), so the
+# overlay lives inside the source bind-mount, not in the /workspace/install volume.
+source /workspace/src/rmw_robotops/e2e_install/local_setup.bash
 
 echo "[publisher] RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
 echo "[publisher] ROBOTOPS_UNDERLYING_RMW=${ROBOTOPS_UNDERLYING_RMW}"

--- a/demo-agent/tests/e2e/scripts/run.sh
+++ b/demo-agent/tests/e2e/scripts/run.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# E2E orchestrator for demo-agent + ROSQL validation.
+#
+# Workflow:
+#   1. Build rmw_robotops dev image and populate the colcon install-cache volume.
+#   2. Build the demo-agent CI image (needed as the agent Dockerfile stage-1 base).
+#   3. Build the three e2e images (publisher, agent, query).
+#   4. Start the agent container in the background.
+#   5. Run the publisher container to completion (scripted turtlesim scenario).
+#   6. Wait a settle window, then SIGINT the agent to trigger final Parquet flush.
+#   7. Run the rosql assertion harness.
+#   8. Report and clean up.
+#
+# Options (env vars):
+#   E2E_SETTLE_SECS        seconds to wait after publisher exits before SIGINT (default: 8)
+#   E2E_ROS_DOMAIN_ID      ROS domain ID to isolate from host traffic (default: 42)
+#   E2E_FILTER_MODE        set to 1 to run the topic-filter variant (default: 0)
+#   E2E_KEEP_OUTPUT        set to 1 to skip cleanup of the Parquet output dir (default: 0)
+#   E2E_OUTPUT_DIR         override the output directory (default: auto temp dir)
+#   APT_REPO_URL           override the RobotOps APT repo (default: https://apt.robotops.com)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+DEMO_AGENT_DIR="$(dirname "$(dirname "$E2E_DIR")")"
+REPO_ROOT="$(dirname "$DEMO_AGENT_DIR")"
+
+SETTLE_SECS="${E2E_SETTLE_SECS:-8}"
+ROS_DOMAIN_ID="${E2E_ROS_DOMAIN_ID:-42}"
+FILTER_MODE="${E2E_FILTER_MODE:-0}"
+KEEP_OUTPUT="${E2E_KEEP_OUTPUT:-0}"
+APT_REPO_URL="${APT_REPO_URL:-https://apt.robotops.com}"
+
+# Compose project name must match the top-level project so we share the named volume
+COMPOSE_PROJECT="rmw_robotops"
+
+OUTPUT_DIR="${E2E_OUTPUT_DIR:-}"
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR="$(mktemp -d /tmp/e2e-rosql-XXXXXX)"
+fi
+
+AGENT_CONTAINER="e2e_agent_run"
+
+log() { echo "[e2e] $*"; }
+
+cleanup() {
+    log "Cleaning up containers..."
+    docker rm -f "$AGENT_CONTAINER" 2>/dev/null || true
+    docker compose \
+        -p e2e \
+        -f "$E2E_DIR/docker-compose.e2e.yml" \
+        down --remove-orphans 2>/dev/null || true
+
+    if [ "$KEEP_OUTPUT" = "0" ] && [ -n "$OUTPUT_DIR" ]; then
+        log "Removing output dir: $OUTPUT_DIR"
+        rm -rf "$OUTPUT_DIR"
+    else
+        log "Parquet output preserved at: $OUTPUT_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# ── Step 1: Build rmw_robotops dev image + populate install-cache volume ──────
+log "Step 1: Building rmw_robotops dev image..."
+docker compose \
+    -p "$COMPOSE_PROJECT" \
+    -f "$REPO_ROOT/docker-compose.yml" \
+    build dev \
+    --build-arg "APT_REPO_URL=${APT_REPO_URL}"
+
+log "Step 1b: Running colcon build to populate install-cache volume..."
+docker compose \
+    -p "$COMPOSE_PROJECT" \
+    -f "$REPO_ROOT/docker-compose.yml" \
+    run --rm build
+
+# ── Step 2: Build demo-agent CI image ────────────────────────────────────────
+log "Step 2: Building robotops-demo-agent:ci image..."
+docker build \
+    -t robotops-demo-agent:ci \
+    --build-arg "APT_REPO_URL=${APT_REPO_URL}" \
+    "$DEMO_AGENT_DIR"
+
+# ── Step 3: Build e2e images ──────────────────────────────────────────────────
+log "Step 3: Building e2e images..."
+
+docker build \
+    -t rmw_robotops-e2e-publisher:latest \
+    -f "$E2E_DIR/Dockerfile.publisher" \
+    "$REPO_ROOT" \
+    --build-arg "APT_REPO_URL=${APT_REPO_URL}"
+
+docker build \
+    -t rmw_robotops-e2e-agent:latest \
+    -f "$E2E_DIR/Dockerfile.agent" \
+    "$DEMO_AGENT_DIR" \
+    --build-arg "APT_REPO_URL=${APT_REPO_URL}"
+
+docker build \
+    -t rmw_robotops-e2e-query:latest \
+    -f "$E2E_DIR/Dockerfile.query" \
+    "$E2E_DIR"
+
+# ── Step 4: Start agent in background ────────────────────────────────────────
+log "Step 4: Starting agent container..."
+docker run \
+    --detach \
+    --name "$AGENT_CONTAINER" \
+    --network host \
+    -e "ROS_DOMAIN_ID=${ROS_DOMAIN_ID}" \
+    -v "${OUTPUT_DIR}:/data" \
+    rmw_robotops-e2e-agent:latest
+
+# ── Step 5: Run publisher to completion ───────────────────────────────────────
+log "Step 5: Running publisher (turtlesim scenario)..."
+
+FILTER_ENV=()
+if [ "$FILTER_MODE" = "1" ]; then
+    log "  Filter mode: ROBOTOPS_TRACE_TOPIC_FILTER='^/turtle1/.*'"
+    FILTER_ENV=(-e "ROBOTOPS_TRACE_TOPIC_FILTER=^/turtle1/.*")
+fi
+
+docker run \
+    --rm \
+    --network host \
+    -e "ROS_DOMAIN_ID=${ROS_DOMAIN_ID}" \
+    -e "RMW_IMPLEMENTATION=rmw_robotops" \
+    -e "ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp" \
+    -e "ROBOTOPS_TRACING_ENABLED=true" \
+    -e "ROBOTOPS_ROBOT_ID=e2e-test-robot" \
+    -e "ROBOTOPS_ORG_ID=e2e-test-org" \
+    "${FILTER_ENV[@]}" \
+    -v "${REPO_ROOT}:/workspace/src/rmw_robotops:ro" \
+    -v "${COMPOSE_PROJECT}_install_cache:/workspace/install:ro" \
+    rmw_robotops-e2e-publisher:latest
+
+log "Publisher finished."
+
+# ── Step 6: Settle, then SIGINT the agent ────────────────────────────────────
+log "Step 6: Waiting ${SETTLE_SECS}s for correlation window + final events..."
+sleep "$SETTLE_SECS"
+
+log "  Sending SIGINT to agent (triggers final Parquet flush)..."
+docker kill --signal SIGINT "$AGENT_CONTAINER" || true
+
+log "  Waiting for agent to flush and exit..."
+docker wait "$AGENT_CONTAINER" || true
+
+# ── Step 7: Run query assertions ──────────────────────────────────────────────
+log "Step 7: Running ROSQL assertion harness..."
+docker run \
+    --rm \
+    -e "E2E_FILTER_MODE=${FILTER_MODE}" \
+    -v "${OUTPUT_DIR}:/data:ro" \
+    -v "${E2E_DIR}/scripts:/tests/scripts:ro" \
+    -v "${E2E_DIR}/queries.yml:/tests/queries.yml:ro" \
+    rmw_robotops-e2e-query:latest \
+    python3 /tests/scripts/assert_queries.py \
+        --data-dir /data \
+        --queries /tests/queries.yml
+
+log "All assertions passed."

--- a/demo-agent/tests/e2e/scripts/run.sh
+++ b/demo-agent/tests/e2e/scripts/run.sh
@@ -2,17 +2,22 @@
 # E2E orchestrator for demo-agent + ROSQL validation.
 #
 # Workflow:
-#   1. Build rmw_robotops dev image and populate the colcon install-cache volume.
-#   2. Build the demo-agent CI image (needed as the agent Dockerfile stage-1 base).
-#   3. Build the three e2e images (publisher, agent, query).
-#   4. Start the agent container in the background.
-#   5. Run the publisher container to completion (scripted turtlesim scenario).
-#   6. Wait a settle window, then SIGINT the agent to trigger final Parquet flush.
-#   7. Run the rosql assertion harness.
-#   8. Report and clean up.
+#   1. Build rmw_robotops dev image and compile a clean RelWithDebInfo overlay
+#      into e2e_build/ / e2e_install/ inside the source tree (isolated from the
+#      ASan-compiled dev/test build).
+#   2. Build the demo-agent CI image (Rust toolchain base for cargo build).
+#   3. Build the combined e2e image (turtlesim + drive_turtle + demo-agent) and
+#      the query image.
+#   4. Run the combined container to completion:
+#        - turtlesim_node under RMW_IMPLEMENTATION=rmw_robotops
+#        - robotops-demo-agent (stock FastDDS, no trace loop)
+#        - drive_turtle.py executes the scripted scenario
+#        - agent is SIGINT'd inside the container after a settle window
+#      Both processes share loopback DDS — no cross-container multicast needed.
+#   5. Run the ROSQL assertion harness against the Parquet output.
 #
 # Options (env vars):
-#   E2E_SETTLE_SECS        seconds to wait after publisher exits before SIGINT (default: 8)
+#   E2E_SETTLE_SECS        seconds to wait after scenario ends before SIGINT (default: 8)
 #   E2E_ROS_DOMAIN_ID      ROS domain ID to isolate from host traffic (default: 42)
 #   E2E_FILTER_MODE        set to 1 to run the topic-filter variant (default: 0)
 #   E2E_KEEP_OUTPUT        set to 1 to skip cleanup of the Parquet output dir (default: 0)
@@ -32,26 +37,14 @@ FILTER_MODE="${E2E_FILTER_MODE:-0}"
 KEEP_OUTPUT="${E2E_KEEP_OUTPUT:-0}"
 APT_REPO_URL="${APT_REPO_URL:-https://apt.robotops.com}"
 
-# Compose project name must match the top-level project so we share the named volume
-COMPOSE_PROJECT="rmw_robotops"
-
 OUTPUT_DIR="${E2E_OUTPUT_DIR:-}"
 if [ -z "$OUTPUT_DIR" ]; then
     OUTPUT_DIR="$(mktemp -d /tmp/e2e-rosql-XXXXXX)"
 fi
 
-AGENT_CONTAINER="e2e_agent_run"
-
 log() { echo "[e2e] $*"; }
 
 cleanup() {
-    log "Cleaning up containers..."
-    docker rm -f "$AGENT_CONTAINER" 2>/dev/null || true
-    docker compose \
-        -p e2e \
-        -f "$E2E_DIR/docker-compose.e2e.yml" \
-        down --remove-orphans 2>/dev/null || true
-
     if [ "$KEEP_OUTPUT" = "0" ] && [ -n "$OUTPUT_DIR" ]; then
         log "Removing output dir: $OUTPUT_DIR"
         rm -rf "$OUTPUT_DIR"
@@ -61,19 +54,31 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ── Step 1: Build rmw_robotops dev image + populate install-cache volume ──────
+# ── Step 1: Build rmw_robotops dev image ─────────────────────────────────────
 log "Step 1: Building rmw_robotops dev image..."
 docker compose \
-    -p "$COMPOSE_PROJECT" \
+    -p rmw_robotops \
     -f "$REPO_ROOT/docker-compose.yml" \
     build dev \
     --build-arg "APT_REPO_URL=${APT_REPO_URL}"
 
-log "Step 1b: Running colcon build to populate install-cache volume..."
-docker compose \
-    -p "$COMPOSE_PROJECT" \
-    -f "$REPO_ROOT/docker-compose.yml" \
-    run --rm build
+# Build rmw_robotops into DEDICATED e2e build/install dirs (e2e_build/ and e2e_install/)
+# inside the source tree. colcon's default ./build and ./install dirs are shared with
+# the dev/test workflow and may contain ASan-compiled artifacts; using separate base
+# dirs guarantees a clean RelWithDebInfo build used by the combined container.
+log "Step 1b: Building colcon overlay into e2e_build/e2e_install (RelWithDebInfo)..."
+docker run --rm \
+    -v "${REPO_ROOT}:/workspace/src/rmw_robotops" \
+    rmw_robotops:dev \
+    bash -c "
+        source /opt/ros/jazzy/setup.bash
+        cd /workspace/src/rmw_robotops
+        colcon build \
+            --build-base e2e_build \
+            --install-base e2e_install \
+            --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            --event-handlers console_direct+
+    "
 
 # ── Step 2: Build demo-agent CI image ────────────────────────────────────────
 log "Step 2: Building robotops-demo-agent:ci image..."
@@ -86,15 +91,9 @@ docker build \
 log "Step 3: Building e2e images..."
 
 docker build \
-    -t rmw_robotops-e2e-publisher:latest \
-    -f "$E2E_DIR/Dockerfile.publisher" \
+    -t rmw_robotops-e2e-combined:latest \
+    -f "$E2E_DIR/Dockerfile.combined" \
     "$REPO_ROOT" \
-    --build-arg "APT_REPO_URL=${APT_REPO_URL}"
-
-docker build \
-    -t rmw_robotops-e2e-agent:latest \
-    -f "$E2E_DIR/Dockerfile.agent" \
-    "$DEMO_AGENT_DIR" \
     --build-arg "APT_REPO_URL=${APT_REPO_URL}"
 
 docker build \
@@ -102,18 +101,8 @@ docker build \
     -f "$E2E_DIR/Dockerfile.query" \
     "$E2E_DIR"
 
-# ── Step 4: Start agent in background ────────────────────────────────────────
-log "Step 4: Starting agent container..."
-docker run \
-    --detach \
-    --name "$AGENT_CONTAINER" \
-    --network host \
-    -e "ROS_DOMAIN_ID=${ROS_DOMAIN_ID}" \
-    -v "${OUTPUT_DIR}:/data" \
-    rmw_robotops-e2e-agent:latest
-
-# ── Step 5: Run publisher to completion ───────────────────────────────────────
-log "Step 5: Running publisher (turtlesim scenario)..."
+# ── Step 4: Run combined container to completion ──────────────────────────────
+log "Step 4: Running combined container (turtlesim + demo-agent + scenario)..."
 
 FILTER_ENV=()
 if [ "$FILTER_MODE" = "1" ]; then
@@ -123,37 +112,28 @@ fi
 
 docker run \
     --rm \
-    --network host \
     -e "ROS_DOMAIN_ID=${ROS_DOMAIN_ID}" \
     -e "RMW_IMPLEMENTATION=rmw_robotops" \
     -e "ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp" \
     -e "ROBOTOPS_TRACING_ENABLED=true" \
     -e "ROBOTOPS_ROBOT_ID=e2e-test-robot" \
     -e "ROBOTOPS_ORG_ID=e2e-test-org" \
-    "${FILTER_ENV[@]}" \
+    -e "E2E_SETTLE_SECS=${SETTLE_SECS}" \
+    ${FILTER_ENV[@]+"${FILTER_ENV[@]}"} \
     -v "${REPO_ROOT}:/workspace/src/rmw_robotops:ro" \
-    -v "${COMPOSE_PROJECT}_install_cache:/workspace/install:ro" \
-    rmw_robotops-e2e-publisher:latest
+    -v "${OUTPUT_DIR}:/data" \
+    -v "${SCRIPT_DIR}:/tests/scripts:ro" \
+    rmw_robotops-e2e-combined:latest
 
-log "Publisher finished."
+log "Combined container finished."
 
-# ── Step 6: Settle, then SIGINT the agent ────────────────────────────────────
-log "Step 6: Waiting ${SETTLE_SECS}s for correlation window + final events..."
-sleep "$SETTLE_SECS"
-
-log "  Sending SIGINT to agent (triggers final Parquet flush)..."
-docker kill --signal SIGINT "$AGENT_CONTAINER" || true
-
-log "  Waiting for agent to flush and exit..."
-docker wait "$AGENT_CONTAINER" || true
-
-# ── Step 7: Run query assertions ──────────────────────────────────────────────
-log "Step 7: Running ROSQL assertion harness..."
+# ── Step 5: Run query assertions ──────────────────────────────────────────────
+log "Step 5: Running ROSQL assertion harness..."
 docker run \
     --rm \
     -e "E2E_FILTER_MODE=${FILTER_MODE}" \
     -v "${OUTPUT_DIR}:/data:ro" \
-    -v "${E2E_DIR}/scripts:/tests/scripts:ro" \
+    -v "${SCRIPT_DIR}:/tests/scripts:ro" \
     -v "${E2E_DIR}/queries.yml:/tests/queries.yml:ro" \
     rmw_robotops-e2e-query:latest \
     python3 /tests/scripts/assert_queries.py \

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.2</version>
+  <version>0.9.3</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/src/rmw_service.cpp
+++ b/src/rmw_service.cpp
@@ -333,7 +333,10 @@ rmw_send_response(
   if (tracing_active) {
     try {
       context = get_or_mint_trace_context();
-      generate_span_id(span_id_buf);
+      // Reuse the span_id set by rmw_take_request (stored in thread-local context)
+      // so EVENT_SERVICE_RESPONSE shares the same span_id as EVENT_SERVICE_REQUEST,
+      // allowing span_reconstructor to correlate the two into a single server span.
+      std::memcpy(span_id_buf, context.span_id, sizeof(span_id_buf));
       start_timestamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
 

--- a/src/rmw_service.cpp
+++ b/src/rmw_service.cpp
@@ -329,19 +329,18 @@ rmw_send_response(
   char span_id_buf[17] = {0};
   uint64_t start_timestamp_ns = 0;
 
-  // STEP 1: Emit START event (BEFORE underlying send)
+  // STEP 1: Capture trace context and record send timestamp (BEFORE underlying send)
+  // Reads the thread-local context written by rmw_take_request on the same thread.
+  // Reusing context.span_id pairs this RESPONSE event with the earlier REQUEST event
+  // so span_reconstructor can merge them into a single SERVER span.
+  // Note: We do NOT inject into DDS metadata for services —
+  // related_sample_identity is reserved for DDS-RPC request-response correlation.
   if (tracing_active) {
     try {
       context = get_or_mint_trace_context();
-      // Reuse the span_id set by rmw_take_request (stored in thread-local context)
-      // so EVENT_SERVICE_RESPONSE shares the same span_id as EVENT_SERVICE_REQUEST,
-      // allowing span_reconstructor to correlate the two into a single server span.
       std::memcpy(span_id_buf, context.span_id, sizeof(span_id_buf));
       start_timestamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
-
-      // Note: We do NOT inject into DDS metadata for services
-      // The related_sample_identity is reserved for DDS-RPC request-response correlation
 
       #ifdef ROS_TRACING_ENABLED
       tracepoint(
@@ -357,7 +356,7 @@ rmw_send_response(
   // STEP 2: REAL RESPONSE FIRST (Safety guarantee)
   rmw_ret_t ret = underlying_rmw_send_response(service, request_header, ros_response);
 
-  // STEP 3: Emit END event
+  // STEP 3: Emit SERVICE_RESPONSE event (paired with SERVICE_REQUEST by shared span_id)
   if (ret == RMW_RET_OK && tracing_active) {
     try {
       #ifdef ROS_TRACING_ENABLED


### PR DESCRIPTION
## Summary

- Adds `demo-agent/tests/e2e/` — a Docker Compose test rig that runs a live turtlesim scenario under `rmw_robotops`, captures Parquet via `demo-agent`, then asserts the output is queryable by `rosql`.
- Adds `.github/workflows/e2e-rosql.yml` — manual `workflow_dispatch` only (not part of regular PR CI).
- Bumps version to `0.9.2` with CHANGELOG entry.

## Coverage

| Capability | How it's exercised |
|---|---|
| PRODUCER spans | `/turtle1/cmd_vel`, `/turtle2/cmd_vel` publish |
| CONSUMER spans | `/turtle1/pose` subscribe (two processes) |
| SERVER spans | `/spawn`, `/kill`, `/turtle1/set_pen` services |
| Action spans | `/turtle1/rotate_absolute` goal/result traffic |
| Cross-process correlation | turtlesim_node ↔ drive_turtle.py (separate OS processes) |
| Logs↔traces correlation | `logger.info()` in pose callback → `trace_id` populated |
| Topic-filter regex | `E2E_FILTER_MODE=1` asserts `/turtle2` spans absent |
| resource_attributes | `robot.id` / `organization.id` flags asserted present |

## Query suite (queries.yml)

11 queries assert `>=1` rows, 3 are parse-only (`>=0`), 1 is the filter-mode check.

## Test plan

- [ ] `just e2e` passes locally (run from `demo-agent/`)
- [ ] GitHub Actions → **E2E ROSQL** → Run workflow on this branch
- [ ] Confirm all `[PASS]` lines in output; inspect uploaded artifact on failure

Closes #46