### PR TITLE
Fix/readme rosdep instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.4 (2026-04-19)
+-------------------
+
+* ``README.md``: fix rosdep install instructions — the old step 2 wrote a raw YAML to ``/etc/ros/rosdep/sources.list.d/``, which ``rosdep`` silently ignores (it only ingests YAML files referenced from ``.list`` entries). ``rosdep install`` failed with "no rosdep rule for [rmw_robotops|robotops_msgs|robotops-config]".
+* ``rosdep/robotops.yaml``: new — ships the rosdep key mappings in-repo so downstream users can register them via a single ``.list`` entry pointing at the raw GitHub URL. Adds the previously missing ``rmw_robotops`` key (step 3 instructs users to ``<depend>rmw_robotops</depend>``, so rosdep must know how to resolve it).
+
 0.9.3 (2026-04-19)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -66,19 +66,21 @@ sudo apt update
 
 **2. Configure rosdep to resolve RobotOps packages**
 
+Register the RobotOps rosdep index by adding a `.list` file that points at the YAML shipped with this repo. `rosdep` only ingests YAML files referenced from `.list` entries — dropping a raw YAML into `sources.list.d/` looks tempting but is silently ignored.
+
 ```bash
 sudo mkdir -p /etc/ros/rosdep/sources.list.d
-sudo tee /etc/ros/rosdep/sources.list.d/robotops.yaml > /dev/null <<EOF
-robotops-config:
-  ubuntu:
-    - ros-jazzy-robotops-config
-
-robotops_msgs:
-  ubuntu:
-    - ros-jazzy-robotops-msgs
+sudo tee /etc/ros/rosdep/sources.list.d/10-robotops.list > /dev/null <<'EOF'
+yaml https://raw.githubusercontent.com/RobotOpsInc/rmw_robotops/main/rosdep/robotops.yaml
 EOF
 
 rosdep update
+```
+
+Verify the keys resolve:
+
+```bash
+rosdep resolve rmw_robotops robotops_msgs robotops-config
 ```
 
 **3. Declare the dependency in your ROS2 package's `package.xml`**

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/rosdep/robotops.yaml
+++ b/rosdep/robotops.yaml
@@ -1,0 +1,11 @@
+rmw_robotops:
+  ubuntu:
+    - ros-jazzy-rmw-robotops
+
+robotops-config:
+  ubuntu:
+    - ros-jazzy-robotops-config
+
+robotops_msgs:
+  ubuntu:
+    - ros-jazzy-robotops-msgs


### PR DESCRIPTION
* ship rosdep mappings in-repo at rosdep/robotops.yaml (includes th epreviously missing rmw_robotops key)
* Include .list file in README pointint at the raw Github URL of the YAML.