### PR TITLE
docs: add env vars to demo quickstart and reorder Usage section

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.5 (2026-04-19)
+-------------------
+
+* ``README.md``: add ``RMW_IMPLEMENTATION`` / ``ROBOTOPS_UNDERLYING_RMW`` env vars to the demo agent quickstart so users know how to activate rmw_robotops before running a node.
+* ``README.md``: move Usage section before FAQ and Benchmarks for better reading order.
+
 0.9.4 (2026-04-19)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,12 @@ curl -fsSL -o robotops-demo-agent \
   https://github.com/RobotOpsInc/rmw_robotops/releases/latest/download/robotops-demo-agent-linux-amd64
 chmod +x robotops-demo-agent
 
-# Run (the session path is printed on startup)
+# Terminal 1: run your ROS2 node with rmw_robotops active
+export RMW_IMPLEMENTATION=rmw_robotops
+export ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
+ros2 run my_package my_node
+
+# Terminal 2: run the demo agent (session path is printed on startup)
 source /opt/ros/jazzy/setup.bash
 ./robotops-demo-agent
 
@@ -125,6 +130,38 @@ rosql query "FROM traces SINCE 1h" \
 For full setup instructions, CLI reference, S3 configuration, and schema documentation see **[demo-agent/README.md](demo-agent/README.md)**.
 
 > `rmw_robotops` is production-ready middleware. `robotops-demo-agent` is a lightweight local evaluation tool — for production-grade telemetry with fleet management, MCAP recording, and offline buffering, see [robotops.com](https://robotops.com).
+
+---
+
+## Usage
+
+### Basic Configuration
+
+```bash
+# Required: Use rmw_robotops as the RMW implementation
+export RMW_IMPLEMENTATION=rmw_robotops
+
+# Required: Specify the underlying RMW to delegate to
+export ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
+
+# Optional: Disable tracing (pure passthrough mode)
+export ROBOTOPS_TRACING_ENABLED=false
+
+# Optional: Topic filter (regex)
+export ROBOTOPS_TRACE_TOPIC_FILTER="^/camera/.*|^/lidar/.*"
+```
+
+### Running with a ROS2 Node
+
+```bash
+# Terminal 1: Run your robot node with rmw_robotops
+export RMW_IMPLEMENTATION=rmw_robotops
+export ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
+ros2 run my_package my_node
+
+# Terminal 2: Monitor trace events
+ros2 topic echo /robotops/trace_events
+```
 
 ---
 
@@ -161,38 +198,6 @@ The benchmark implementation is in progress. Performance targets:
 | Added latency (median) | < 1µs per message |
 | CPU overhead | < 5% vs underlying RMW |
 | Hot-path allocations | Zero |
-
----
-
-## Usage
-
-### Basic Configuration
-
-```bash
-# Required: Use rmw_robotops as the RMW implementation
-export RMW_IMPLEMENTATION=rmw_robotops
-
-# Required: Specify the underlying RMW to delegate to
-export ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
-
-# Optional: Disable tracing (pure passthrough mode)
-export ROBOTOPS_TRACING_ENABLED=false
-
-# Optional: Topic filter (regex)
-export ROBOTOPS_TRACE_TOPIC_FILTER="^/camera/.*|^/lidar/.*"
-```
-
-### Running with a ROS2 Node
-
-```bash
-# Terminal 1: Run your robot node with rmw_robotops
-export RMW_IMPLEMENTATION=rmw_robotops
-export ROBOTOPS_UNDERLYING_RMW=rmw_fastrtps_cpp
-ros2 run my_package my_node
-
-# Terminal 2: Monitor trace events
-ros2 topic echo /robotops/trace_events
-```
 
 ## Configuration
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.4</version>
+  <version>0.9.5</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
## Summary

- Add `RMW_IMPLEMENTATION` and `ROBOTOPS_UNDERLYING_RMW` exports to the demo agent quickstart — users following the README had no indication they needed to set these before running their ROS2 node
- Move the Usage section immediately after Installation, before FAQ and Benchmarks, so the reading order flows naturally

## Test plan

- [ ] Read through the Installation → Try it out → Usage flow in the rendered README and confirm it reads logically end-to-end