### PR TITLE
[rmw_robotops] Update docs and demo prose to TraceHouse

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -412,7 +412,7 @@ Thread A:
 
 **Result:** trace_id propagates across pub→sub on same thread
 
-### Cross-Process Propagation (Different Processes)
+### Cross-Process Correlation (Different Processes)
 
 **Scenario:** Publisher (Process A) → Subscriber (Process B)
 
@@ -430,13 +430,13 @@ Process A:
 │       - timestamp_ns: 1234567890123456                  │
 └─────────────────────────────────────────────────────────┘
                     │
-                    │ DDS message (NO trace context injected)
+                    │ DDS message (NO trace context injected or modified)
                     │
                     ▼
 Process B:
 ┌─────────────────────────────────────────────────────────┐
 │ rmw_take_with_info()                                    │
-│   ├─ extracted_context = get_trace_context()  // EMPTY! │
+│   ├─ // No DDS trace context is available              │
 │   ├─ // No context in TLS (different process)           │
 │   ├─ generate_trace_id(new_context.trace_id)            │
 │   │   // Mint NEW trace_id: "xyz789..."                 │
@@ -467,7 +467,7 @@ Process B:
 └─────────────────────────────────────────────────────────┘
 ```
 
-**Result:** Two separate traces correlated post-hoc by robot_agent
+**Result:** Two separate traces are correlated post-hoc by robot_agent using `publisher_gid`, `source_timestamp_ns`, and `content_hash` metadata.
 
 ### Fan-In Detection (Multiple Publishers → One Subscriber)
 
@@ -500,7 +500,7 @@ TraceEvent emitted:
 
 ### DDS-Agnostic Approach (Current Implementation)
 
-**Philosophy:** Never inject into DDS, correlate post-hoc using observable metadata.
+**Philosophy:** Never inject trace context into DDS messages or headers; correlate post-hoc using observable RMW metadata.
 
 #### Intra-Process Correlation
 
@@ -523,9 +523,10 @@ TraceEvent emitted:
 - `content_hash` (xxHash64 of message content via introspection)
 
 **How correlation works:**
-1. Publisher emits TraceEvent with: `{trace_id_A, publisher_gid, timestamp, content_hash}`
-2. Subscriber emits TraceEvent with: `{trace_id_B, publisher_gid, timestamp, content_hash}`
-3. robot_agent matches events where:
+1. Publisher sends the original DDS message unchanged; no trace context is injected.
+2. Publisher emits TraceEvent with: `{trace_id_A, publisher_gid, timestamp, content_hash}`
+3. Subscriber emits TraceEvent with: `{trace_id_B, publisher_gid, timestamp, content_hash}`
+4. robot_agent matches events post-hoc where:
    - `publisher_gid` matches exactly
    - `source_timestamp_ns` matches exactly
    - `content_hash` matches exactly

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # rmw_robotops
 
-ROS2 RMW (ROS Middleware) implementation that wraps any underlying RMW (FastDDS, CycloneDDS, etc.) to add distributed tracing capabilities with OpenTelemetry-compatible context propagation.
+ROS2 RMW (ROS Middleware) implementation that wraps any underlying RMW (FastDDS, CycloneDDS, etc.) to add distributed tracing capabilities with OpenTelemetry-compatible trace correlation.
 
 ## Overview
 
 `rmw_robotops` is a **safety-critical** RMW layer that:
 
 - Intercepts all ROS2 pub/sub/service/action communication
-- Propagates trace context (trace_id, span_id) through DDS metadata
+- Tracks local trace context and emits DDS-agnostic correlation metadata
 - Publishes trace events to `/robotops/trace_events` for collection
 - Maintains 8 critical safety guarantees to ensure robot operation is never compromised
 
@@ -17,7 +17,7 @@ ROS2 RMW (ROS Middleware) implementation that wraps any underlying RMW (FastDDS,
 2. **Best-Effort QoS** - Trace events never block the system
 3. **No allocations in hot path** - Pre-allocated thread-local buffers
 4. **No exceptions propagate** - All trace code is `noexcept`
-5. **Lock-free context propagation** - Thread-local storage only
+5. **Lock-free context tracking** - Thread-local storage only
 6. **Runtime kill switch** - Zero overhead when disabled
 7. **Auto-disable on failures** - Self-protecting circuit breaker
 8. **Background thread for publishing** - Non-blocking queue from robot threads
@@ -34,7 +34,7 @@ ROS2 RMW (ROS Middleware) implementation that wraps any underlying RMW (FastDDS,
 │   │   rmw_publish() → [Real Message First]              │   │
 │   │                 → [Best-Effort Trace Event]         │   │
 │   │                                                     │   │
-│   │   rmw_take()    → [Extract Context from DDS]        │   │
+│   │   rmw_take()    → [Correlate from RMW Metadata]     │   │
 │   │                 → [Set Thread-Local Context]        │   │
 │   │                                                     │   │
 │   │   Background Thread → [/robotops/trace_events]      │   │
@@ -46,15 +46,15 @@ ROS2 RMW (ROS Middleware) implementation that wraps any underlying RMW (FastDDS,
 └─────────────────────────────────────────────────────────────┘
 ```
 
-For a deep dive into component responsibilities, data flows, safety guarantees, trace context propagation, thread safety, and edge cases, see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+For a deep dive into component responsibilities, data flows, safety guarantees, trace context tracking and correlation, thread safety, and edge cases, see **[ARCHITECTURE.md](ARCHITECTURE.md)**.
 
 ---
 
 ## Installation
 
-Building from source ensures ABI compatibility with your exact environment — compiler version, glibc, FastDDS version, etc. Dependencies are fetched from the public RobotOps APT repository (no credentials required).
+Building from source ensures ABI compatibility with your exact environment — compiler version, glibc, FastDDS version, etc. Dependencies are fetched from the public TraceHouse APT repository (no credentials required).
 
-**1. Add the RobotOps APT repository**
+**1. Add the TraceHouse APT repository**
 
 ```bash
 curl -fsSL https://apt.robotops.com/robotops-public-key.asc \
@@ -64,9 +64,9 @@ echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] https://a
 sudo apt update
 ```
 
-**2. Configure rosdep to resolve RobotOps packages**
+**2. Configure rosdep to resolve TraceHouse packages**
 
-Register the RobotOps rosdep index by adding a `.list` file that points at the YAML shipped with this repo. `rosdep` only ingests YAML files referenced from `.list` entries — dropping a raw YAML into `sources.list.d/` looks tempting but is silently ignored.
+Register the TraceHouse rosdep index by adding a `.list` file that points at the YAML shipped with this repo. `rosdep` only ingests YAML files referenced from `.list` entries — dropping a raw YAML into `sources.list.d/` looks tempting but is silently ignored.
 
 ```bash
 sudo mkdir -p /etc/ros/rosdep/sources.list.d
@@ -129,7 +129,7 @@ rosql query "FROM traces SINCE 1h" \
 
 For full setup instructions, CLI reference, S3 configuration, and schema documentation see **[demo-agent/README.md](demo-agent/README.md)**.
 
-> `rmw_robotops` is production-ready middleware. `robotops-demo-agent` is a lightweight local evaluation tool — for production-grade telemetry with fleet management, MCAP recording, and offline buffering, see [robotops.com](https://robotops.com).
+> `rmw_robotops` is production-ready middleware. `robotops-demo-agent` is a lightweight local evaluation tool — for production-grade telemetry with fleet management, MCAP recording, and offline buffering, see [TraceHouse](https://robotops.com).
 
 ---
 
@@ -315,7 +315,7 @@ This repository uses **semantic versioning** expressed in `package.xml` and enfo
 
 ### Lockstep Major Versions
 
-**Major versions** move in lockstep across the entire RobotOps ecosystem:
+**Major versions** move in lockstep across the entire TraceHouse ecosystem:
 
 - `robotops_config`
 - `robotops_msgs`

--- a/demo-agent/Dockerfile
+++ b/demo-agent/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     gpg \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure RobotOps APT repository and install robotops-msgs
+# Configure TraceHouse APT repository and install robotops-msgs
 # (r2r needs the message type support libraries at build and runtime)
 RUN curl -fsSL https://apt.robotops.com/robotops-public-key.asc \
         | gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg && \

--- a/demo-agent/README.md
+++ b/demo-agent/README.md
@@ -4,7 +4,7 @@ Lightweight local evaluation companion for `rmw_robotops`.
 
 Subscribes to `/robotops/trace_events`, `/robotops/trace_context`, and `/rosout`, reconstructs distributed trace spans, and writes OTel-compatible Parquet files you can query with ROSQL.
 
-`rmw_robotops` is production-ready middleware. This demo agent is a local evaluation tool — for production-grade telemetry with fleet management, MCAP recording, and offline buffering, see [robotops.com](https://robotops.com).
+`rmw_robotops` is production-ready middleware. This demo agent is a local evaluation tool — for production-grade telemetry with fleet management, MCAP recording, and offline buffering, see [TraceHouse](https://robotops.com).
 
 ---
 
@@ -21,7 +21,7 @@ Subscribes to `/robotops/trace_events`, `/robotops/trace_context`, and `/rosout`
 ## 1. Install rmw_robotops
 
 ```bash
-# Add RobotOps APT repository (one-time setup)
+# Add TraceHouse APT repository (one-time setup)
 curl -fsSL https://apt.robotops.com/robotops-public-key.asc \
   | sudo gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] https://apt.robotops.com noble main" \
@@ -296,7 +296,7 @@ troubleshooting.
 
 ## Limitations
 
-- **Demo agent only.** `rmw_robotops` is production-ready, but this agent is a local evaluation tool — no system metrics, TF monitoring, MCAP recording, offline buffering, or fleet management. For production use, see [robotops.com](https://robotops.com).
+- **Demo agent only.** `rmw_robotops` is production-ready, but this agent is a local evaluation tool — no system metrics, TF monitoring, MCAP recording, offline buffering, or fleet management. For production use, see [TraceHouse](https://robotops.com).
 - S3 writes are synchronous (blocking) — not suitable for high-throughput environments.
 - Span reconstruction requires matched START/END events. Spans in-flight at shutdown will be incomplete.
 - The correlation window (`--correlation-window-secs`) limits how far back publish events are retained for cross-process matching.

--- a/demo-agent/src/cli.rs
+++ b/demo-agent/src/cli.rs
@@ -12,7 +12,7 @@ use clap::Parser;
                   for querying with ROSQL or DuckDB.\n\n\
                   This is a demo/evaluation tool — not for production. For production deployments\n\
                   with system metrics, TF monitoring, MCAP recording, offline buffering, and\n\
-                  fleet management, use Robot Ops' robot_agent: https://robotops.com"
+                  fleet management, use TraceHouse's robot_agent: https://robotops.com"
 )]
 pub struct Cli {
     /// Output path: local directory or s3:// URI.

--- a/demo-agent/src/main.rs
+++ b/demo-agent/src/main.rs
@@ -9,7 +9,7 @@
 //!
 //! **This is a demo/evaluation tool — not for production.** For production deployments
 //! with system metrics, TF monitoring, MCAP recording, offline buffering, and fleet
-//! management, use Robot Ops' robot_agent: https://robotops.com.
+//! management, use TraceHouse's robot_agent: https://robotops.com.
 
 mod cli;
 mod error;

--- a/demo-agent/tests/e2e/Dockerfile.publisher
+++ b/demo-agent/tests/e2e/Dockerfile.publisher
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Publisher container: ROS2 Jazzy + rmw_robotops (from colcon overlay) + turtlesim.
 # Extend the top-level dev stage which already has all rmw_robotops build deps,
-# the apt.robotops.com repo, and robotops-msgs.
+# the TraceHouse APT repo, and robotops-msgs.
 FROM rmw_robotops:dev
 
 # Add turtlesim, rclpy, and Xvfb for headless GUI

--- a/demo-agent/tests/e2e/README.md
+++ b/demo-agent/tests/e2e/README.md
@@ -45,7 +45,7 @@ E2E_FILTER_MODE=1 just e2e
 | `E2E_FILTER_MODE` | `0` | Set to `1` to run the topic-filter variant |
 | `E2E_KEEP_OUTPUT` | `0` | Set to `1` to preserve the Parquet session dir |
 | `E2E_OUTPUT_DIR` | auto temp | Override the Parquet output directory |
-| `APT_REPO_URL` | `https://apt.robotops.com` | Override the RobotOps APT repo |
+| `APT_REPO_URL` | `https://apt.robotops.com` | Override the TraceHouse APT repo |
 
 ## Query suite
 

--- a/demo-agent/tests/e2e/scripts/run.sh
+++ b/demo-agent/tests/e2e/scripts/run.sh
@@ -22,7 +22,7 @@
 #   E2E_FILTER_MODE        set to 1 to run the topic-filter variant (default: 0)
 #   E2E_KEEP_OUTPUT        set to 1 to skip cleanup of the Parquet output dir (default: 0)
 #   E2E_OUTPUT_DIR         override the output directory (default: auto temp dir)
-#   APT_REPO_URL           override the RobotOps APT repo (default: https://apt.robotops.com)
+#   APT_REPO_URL           override the TraceHouse APT repo (default: https://apt.robotops.com)
 
 set -euo pipefail
 


### PR DESCRIPTION
Updates public-facing rmw_robotops docs/demo prose to TraceHouse wording while preserving dependency-facing identifiers and robotops.com URLs.\n\nVerification: doc/string-only changes; no code behavior changes.