### PR TITLE
docs: add generative AI contributions policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ Do not write vault pages directly.
 
 This file documents project-specific rules and conventions for AI-assisted development.
 
+## AI Contribution Policy
+
+When using generative AI assistance for a contribution, follow the public policy in `CONTRIBUTING.md`: review and test all generated content, do not expose confidential or third-party content without permission, and disclose meaningful AI assistance in the commit message or pull request description.
+
 ## Git Workflow
 
 ### Branching Strategy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,20 @@ Thank you for your interest in contributing to rmw_robotops! This document provi
 
 Please be respectful and considerate in all interactions with the project and its community.
 
+## Generative AI Contributions Policy
+
+Contributions may use generative AI tools, but contributors are responsible for reviewing, testing, and maintaining everything they submit. Do not include confidential, proprietary, or third-party content in prompts or generated output unless you have the right to share and license it to RobotOps.
+
+Disclose meaningful generative AI assistance in the commit message or pull request description so reviewers can evaluate the change with the right context.
+
+Example commit message disclosure:
+
+```text
+Docs: add troubleshooting note
+
+AI-assisted: drafted with Claude and reviewed/edited by the contributor.
+```
+
 ## Getting Started
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ rmw_robotops/
 
 ## Development
 
-For development setup, workflow, testing, and contribution guidelines, see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
+For development setup, workflow, testing, and contribution guidelines, including the Generative AI Contributions Policy, see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## License
 


### PR DESCRIPTION
Adds the ROB-262 public-facing Generative AI contributions policy to CONTRIBUTING.md, README.md, and CLAUDE.md.