### PR TITLE
docs: add generative AI contribution policy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.6 (2026-05-29)
+-------------------
+
+* ``CONTRIBUTING.md`` / ``README.md`` / ``CLAUDE.md``: add the Generative AI contributions policy and remind contributors to review AI-assisted work before submission.
+
 0.9.5 (2026-04-19)
 -------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ Do not write vault pages directly.
 
 This file documents project-specific rules and conventions for AI-assisted development.
 
+## AI Contribution Policy
+
+Remind developers to disclose substantial AI-generated content in the commit message and pull request description. Do not stage or submit commits on the developer's behalf without explicit confirmation.
+
 ## Git Workflow
 
 ### Branching Strategy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,16 @@ Thank you for your interest in contributing to rmw_robotops! This document provi
 
 Please be respectful and considerate in all interactions with the project and its community.
 
+## Use of Generative AI Tools
+
+Robot Ops permits contributions produced in whole or in part with generative AI tools, consistent with OSRF's policy. Disclose AI assistance when contributing, including in the commit message and pull request description. Contributors own the result and must review, test, and verify that it is correct, safe, licensed appropriately, and does not include confidential or unauthorized third-party content.
+
+Commit message disclosure example:
+
+```text
+AI-Assisted: This contribution includes content generated with generative AI tools and reviewed by the contributor.
+```
+
 ## Getting Started
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -387,3 +387,7 @@ For development setup, workflow, testing, and contribution guidelines, see **[CO
 ## License
 
 Apache-2.0
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines, including the generative AI disclosure policy.

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.5</version>
+  <version>0.9.6</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
## Summary
- Add generative AI disclosure policy to CONTRIBUTING.md
- Point README readers to the policy
- Add AI assistant instructions to CLAUDE.md

## Validation
- git diff --check
- git diff --stat

AI-Assisted: This contribution includes content generated with generative AI tools and reviewed by the contributor.