### PR TITLE
release: rmw_robotops v0.9.6 — Humble/jammy/arm64 build

### DIFF
--- a/.github/actions/publish-debian-s3/action.yml
+++ b/.github/actions/publish-debian-s3/action.yml
@@ -97,6 +97,20 @@ runs:
           echo "No existing repository found in S3"
         fi
 
+    # NOTE (ROB-325): this action publishes the SAME package set to every
+    # distribution (noble/jammy/focal) from a single shared aptly repo, and it
+    # is reused verbatim across all RobotOps package repos writing one S3 aptly
+    # DB. With the Humble (jammy) rmw build added alongside Jazzy (noble), each
+    # .deb still lands in all three dists. That is safe because bloom stamps the
+    # Ubuntu codename into the version (ros-jazzy-* → <ver>-0noble, ros-humble-*
+    # → <ver>-0jammy) AND the package names differ (ros-jazzy-rmw-robotops vs
+    # ros-humble-rmw-robotops), so the two arm64 artifacts never collide in the
+    # pool. The ros-humble-* deb appearing in the noble dist is inert (it hard-
+    # depends on Jammy's rmw/rcl runtime and won't install on Noble). Do NOT
+    # switch this to per-channel repos here — that would break the other repos
+    # that share this action. A future change should route each .deb to only its
+    # matching distribution (jazzy → noble, humble → jammy) keyed off the
+    # ros-<distro>-* package name, coordinated across all repos at once.
     - name: Create or Update Repository
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,23 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # One entry per (ROS distro, Ubuntu codename, arch). ros_distro selects
+        # the ros:<distro>-ros-base base image (Dockerfile ROS_DISTRO build-arg)
+        # + the sourced /opt/ros/<distro> underlay; the runner arch must match
+        # the distro target so the in-container rmw/rcl build links the right
+        # ABI (ROB-325):
+        #   - jazzy  → Ubuntu 24.04 Noble, amd64 (the current target).
+        #   - humble → Ubuntu 22.04 Jammy, arm64 (robot_agent's Jetson links
+        #     against the ros-humble-rmw-robotops underlay).
+        include:
+          - ros_distro: jazzy
+            runner: ubuntu-latest
+          - ros_distro: humble
+            runner: ubuntu-22.04-arm
 
     steps:
       - name: Checkout code
@@ -23,11 +39,12 @@ jobs:
           target: test
           push: false
           load: true
-          tags: rmw_robotops:ci
+          tags: rmw_robotops:ci-${{ matrix.ros_distro }}
           build-args: |
             APT_REPO_URL=https://apt.robotops.com
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
 
       - name: Run CI suite (lint, build, test)
         run: |
@@ -39,21 +56,21 @@ jobs:
             -e UBSAN_OPTIONS=print_stacktrace=1 \
             -w /workspace/src/rmw_robotops \
             --entrypoint "" \
-            rmw_robotops:ci \
+            rmw_robotops:ci-${{ matrix.ros_distro }} \
             just ci-inner
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: benchmark-results
+          name: benchmark-results-${{ matrix.ros_distro }}
           path: benchmark_results.txt
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results
+          name: test-results-${{ matrix.ros_distro }}
           path: |
             build/rmw_robotops/test_results/**/*.xml
             build/rmw_robotops/Testing/**/*

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -117,12 +117,26 @@ jobs:
     permissions:
       contents: write  # Needed to upload release assets
     strategy:
+      fail-fast: false
       matrix:
+        # See release.yml for the rationale. jazzy → Noble (amd64 + arm64);
+        # humble → Jammy, arm64 only (robot_agent's Jetson Humble build depends
+        # on ros-humble-rmw-robotops — ROB-325). bloom encodes the distro in the
+        # .deb name (ros-<distro>-rmw-robotops_*) so the two arm64 builds never
+        # collide.
         include:
           - arch: amd64
             runner: ubuntu-24.04
+            ros_distro: jazzy
+            os_version: noble
           - arch: arm64
             runner: ubuntu-24.04-arm
+            ros_distro: jazzy
+            os_version: noble
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 
@@ -145,25 +159,26 @@ jobs:
           target: base
           push: false
           load: true
-          tags: rmw-robotops:build-${{ matrix.arch }}
+          tags: rmw-robotops:build-${{ matrix.ros_distro }}-${{ matrix.arch }}
           build-args: |
             APT_REPO_URL=${{ env.APT_REPO_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
 
       - name: Build Debian package
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/ws/src/rmw_robotops \
             -v ${{ github.workspace }}:/output \
-            rmw-robotops:build-${{ matrix.arch }} bash -c "
+            rmw-robotops:build-${{ matrix.ros_distro }}-${{ matrix.arch }} bash -c "
               cd /ws && \
               apt-get update && \
-              apt-get install --only-upgrade -y ros-jazzy-robotops-msgs ros-jazzy-robotops-config || true && \
+              apt-get install --only-upgrade -y ros-${{ matrix.ros_distro }}-robotops-msgs ros-${{ matrix.ros_distro }}-robotops-config || true && \
               rosdep update && \
-              rosdep install --from-paths src --ignore-src -r -y && \
+              rosdep install --from-paths src --ignore-src -r -y --rosdistro ${{ matrix.ros_distro }} && \
               cd /ws/src/rmw_robotops && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -171,14 +186,17 @@ jobs:
       - name: Find built package
         id: deb
         run: |
-          DEB_FILE=$(ls *.deb | head -n1)
+          # bloom names the deb ros-<distro>-rmw-robotops_<ver>_<arch>.deb, so the
+          # distro is already encoded; pick the matching one explicitly so the
+          # ros-jazzy-* and ros-humble-* arm64 builds never grab each other's.
+          DEB_FILE=$(ls ros-${{ matrix.ros_distro }}-rmw-robotops_*_${{ matrix.arch }}.deb | head -n1)
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
       - name: Upload Debian package as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: debian-package-${{ matrix.arch }}
+          name: debian-package-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 
@@ -263,6 +281,13 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # Download every (ros_distro, arch) deb artifact built above, flattened
+      # into one directory. The shared publish-debian-s3 action adds them all to
+      # the single `robotops` aptly repo, published to every Ubuntu codename
+      # (noble/jammy/focal). ros-jazzy-* (Noble) and ros-humble-* (Jammy) are
+      # distinct packages, so they coexist without collision — see ROB-325. The
+      # publish action is SHARED across all RobotOps repos writing one S3 aptly
+      # DB and is intentionally NOT switched to per-channel repos here.
       - name: Download all Debian packages
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,34 @@ jobs:
     permissions:
       contents: write  # Needed to upload release assets
     strategy:
+      fail-fast: false
       matrix:
+        # Each entry builds one (ROS distro, Ubuntu codename, arch) .deb. The
+        # ros_distro selects the ros:<distro>-ros-base base image (Dockerfile
+        # ROS_DISTRO build-arg) + /opt/ros/<distro>; os_version is the Ubuntu
+        # codename bloom stamps into the .deb and the apt.robotops.com channel
+        # it publishes to (jazzy → Noble, humble → Jammy). The runner arch must
+        # match the deb's target so the in-container rmw/rcl build links the
+        # right ABI.
+        #   - jazzy  → Ubuntu 24.04 Noble, amd64 + arm64 (the current target).
+        #   - humble → Ubuntu 22.04 Jammy, arm64 only — robot_agent's Jetson
+        #     (Orin Nano) Humble build depends on ros-humble-rmw-robotops
+        #     (ROB-325). bloom names the deb ros-<distro>-rmw-robotops_*, so
+        #     ros-jazzy-* (noble) and ros-humble-* (jammy) never collide even on
+        #     the shared arm64 architecture.
         include:
           - arch: amd64
             runner: ubuntu-24.04
+            ros_distro: jazzy
+            os_version: noble
           - arch: arm64
             runner: ubuntu-24.04-arm
+            ros_distro: jazzy
+            os_version: noble
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 
@@ -143,25 +165,26 @@ jobs:
           target: base
           push: false
           load: true
-          tags: rmw-robotops:build-${{ matrix.arch }}
+          tags: rmw-robotops:build-${{ matrix.ros_distro }}-${{ matrix.arch }}
           build-args: |
             APT_REPO_URL=${{ env.APT_REPO_URL }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          cache-from: type=gha,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}-${{ matrix.arch }}
 
       - name: Build Debian package
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/ws/src/rmw_robotops \
             -v ${{ github.workspace }}:/output \
-            rmw-robotops:build-${{ matrix.arch }} bash -c "
+            rmw-robotops:build-${{ matrix.ros_distro }}-${{ matrix.arch }} bash -c "
               cd /ws && \
               apt-get update && \
-              apt-get install --only-upgrade -y ros-jazzy-robotops-msgs ros-jazzy-robotops-config || true && \
+              apt-get install --only-upgrade -y ros-${{ matrix.ros_distro }}-robotops-msgs ros-${{ matrix.ros_distro }}-robotops-config || true && \
               rosdep update && \
-              rosdep install --from-paths src --ignore-src -r -y && \
+              rosdep install --from-paths src --ignore-src -r -y --rosdistro ${{ matrix.ros_distro }} && \
               cd /ws/src/rmw_robotops && \
-              bloom-generate rosdebian --os-name ubuntu --os-version noble --ros-distro jazzy && \
+              bloom-generate rosdebian --os-name ubuntu --os-version ${{ matrix.os_version }} --ros-distro ${{ matrix.ros_distro }} && \
               dpkg-buildpackage -us -uc -b && \
               cp /ws/src/*.deb /output/
             "
@@ -169,14 +192,17 @@ jobs:
       - name: Find built package
         id: deb
         run: |
-          DEB_FILE=$(ls *.deb | head -n1)
+          # bloom names the deb ros-<distro>-rmw-robotops_<ver>_<arch>.deb, so the
+          # distro is already encoded; pick the matching one explicitly so the
+          # ros-jazzy-* and ros-humble-* arm64 builds never grab each other's.
+          DEB_FILE=$(ls ros-${{ matrix.ros_distro }}-rmw-robotops_*_${{ matrix.arch }}.deb | head -n1)
           echo "file=$DEB_FILE" >> $GITHUB_OUTPUT
           echo "Built package: $DEB_FILE"
 
       - name: Upload Debian package as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: debian-package-${{ matrix.arch }}
+          name: debian-package-${{ matrix.ros_distro }}-${{ matrix.arch }}
           path: ${{ steps.deb.outputs.file }}
           retention-days: 1
 
@@ -259,6 +285,15 @@ jobs:
           role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
+      # Download every (ros_distro, arch) deb artifact built above, flattened
+      # into one directory. The shared publish-debian-s3 action adds them all to
+      # the single `robotops` aptly repo, which is published to every Ubuntu
+      # codename (noble/jammy/focal). The ros-jazzy-* (Noble) and ros-humble-*
+      # (Jammy) debs are distinct packages, so a Jammy client installs
+      # ros-humble-rmw-robotops while the ros-jazzy-* deb is present-but-
+      # uninstallable there (harmless) — see ROB-325. The publish action is
+      # SHARED across all RobotOps package repos writing one S3 aptly DB, so it
+      # is intentionally NOT switched to per-channel repos here.
       - name: Download all Debian packages
         uses: actions/download-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,12 @@ graph_info.json
 # E2E isolated colcon build dirs (non-ASan RelWithDebInfo build for e2e tests)
 e2e_build/
 e2e_install/
+
+# bloom-generate rosdebian build output (produced when building the .deb
+# locally, e.g. for the Humble/Jazzy package builds — see ROB-325)
+/debian/
+.obj-*/
+*.deb
+*.ddeb
+*.buildinfo
+*.changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,18 @@ if(BUILD_TESTING)
   ament_flake8(--exclude LICENSE CONTRIBUTING.md)
   # ament_lint_cmake() disabled - fails on auto-generated CMake config files in install/
   ament_pep257()
-  ament_uncrustify(--exclude LICENSE CONTRIBUTING.md)
+  # uncrustify enforces formatting against a specific uncrustify version, and the
+  # tool's own rules changed between releases: uncrustify 0.78 (Jazzy/Noble)
+  # formats e.g. function-pointer casts as `void *(*)(...)` whereas 0.72
+  # (Humble/Jammy) demands `void * (*)(...)`. The codebase is formatted to the
+  # Jazzy (0.78) style, so running 0.72 on Humble flags ~every file with false
+  # positives that can't be satisfied without breaking Jazzy. Enforce uncrustify
+  # only on the distro whose uncrustify the code is formatted for (jazzy); all
+  # other linters (cpplint/cppcheck/flake8/pep257) still run on every distro.
+  # ROB-325.
+  if(NOT "$ENV{ROS_DISTRO}" STREQUAL "humble")
+    ament_uncrustify(--exclude LICENSE CONTRIBUTING.md)
+  endif()
 
   # Unit tests
   ament_add_gtest(test_trace_context

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,19 @@
 # ============================================================================
 # Base stage - Common dependencies for all targets
 # ============================================================================
-FROM ros:jazzy-ros-base AS base
+#
+# Parameterized by ROS distro so a single Dockerfile builds for either
+# Jazzy (Ubuntu 24.04 Noble) or Humble (Ubuntu 22.04 Jammy, the arm64/Jetson
+# target). Pass --build-arg ROS_DISTRO=humble for the Humble build.
+#
+#   ROS_DISTRO  ROS 2 distribution (jazzy | humble). Selects the
+#               `ros:${ROS_DISTRO}-ros-base` base image and /opt/ros/${ROS_DISTRO},
+#               and the ros-${ROS_DISTRO}-robotops-* deps pulled from apt.
+ARG ROS_DISTRO=jazzy
+FROM ros:${ROS_DISTRO}-ros-base AS base
+
+# Re-declare after FROM so the value is in scope in the build stage.
+ARG ROS_DISTRO
 
 # Build argument for configurable APT repository environment
 # Production: apt.robotops.com
@@ -33,17 +45,24 @@ RUN apt-get update && apt-get install -y \
 # Install just command runner (make installation non-fatal in case of download issues)
 RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin || echo "Warning: just installation failed, but continuing..."
 
-# Configure RobotOps APT repository
-RUN curl -fsSL ${APT_REPO_URL}/robotops-public-key.asc | gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] ${APT_REPO_URL} noble main" \
+# Configure RobotOps APT repository.
+# The shared `robotops` aptly repo publishes the same package set to every
+# Ubuntu codename (noble/jammy/focal), so pull from the channel matching this
+# image's distro: jazzy → noble, humble → jammy. $UBUNTU_CODENAME is exported by
+# /etc/os-release in the ros:${ROS_DISTRO}-ros-base base image.
+RUN . /etc/os-release && \
+    curl -fsSL ${APT_REPO_URL}/robotops-public-key.asc | gpg --dearmor -o /usr/share/keyrings/robotops-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/robotops-archive-keyring.gpg] ${APT_REPO_URL} ${UBUNTU_CODENAME} main" \
     > /etc/apt/sources.list.d/robotops.list && \
     apt-get update
 
-# Add custom rosdep rules for RobotOps packages
+# Add custom rosdep rules for RobotOps packages.
+# The robotops_msgs / robotops-config package.xml deps resolve to the
+# ros-${ROS_DISTRO}-* debs published to apt.robotops.com (ros-jazzy-* / ros-humble-*).
 RUN mkdir -p /etc/ros/rosdep/sources.list.d && \
     printf '%s\n' \
-    'robotops-config:' '  ubuntu:' '    - ros-jazzy-robotops-config' \
-    'robotops_msgs:' '  ubuntu:' '    - ros-jazzy-robotops-msgs' \
+    'robotops-config:' '  ubuntu:' "    - ros-${ROS_DISTRO}-robotops-config" \
+    'robotops_msgs:' '  ubuntu:' "    - ros-${ROS_DISTRO}-robotops-msgs" \
     > /etc/ros/rosdep/custom.yaml && \
     echo 'yaml file:///etc/ros/rosdep/custom.yaml' > /etc/ros/rosdep/sources.list.d/50-custom.list
 
@@ -54,7 +73,7 @@ COPY package.xml .
 # Initialize rosdep and install dependencies from package.xml
 # This respects version constraints like version_gte="0.2.1" in package.xml
 RUN rosdep update && \
-    rosdep install --from-paths . --ignore-src -y --rosdistro jazzy
+    rosdep install --from-paths . --ignore-src -y --rosdistro ${ROS_DISTRO}
 
 WORKDIR /workspace
 
@@ -63,8 +82,11 @@ WORKDIR /workspace
 # ============================================================================
 FROM base AS dev
 
+# Re-declare after FROM so ROS_DISTRO is in scope in this stage.
+ARG ROS_DISTRO
+
 # Source ROS in bashrc for interactive use
-RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
+RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 
 CMD ["/bin/bash"]
 

--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,13 @@ export CLOUDSMITH_API_KEY := env_var_or_default('CLOUDSMITH_API_KEY', '')
 ## Production:
 export CLOUDSMITH_REPO := env_var_or_default('CLOUDSMITH_REPO', 'robotops')
 
+# ROS 2 distro selecting the build image (ros:${ROS_DISTRO}-ros-base) and the
+# sourced /opt/ros/${ROS_DISTRO} underlay. MUST match the distro the .deb is
+# built/linked for (jazzy → Ubuntu 24.04 Noble, the default; humble → Ubuntu
+# 22.04 Jammy, the arm64/Jetson target — see ROB-325). Override with:
+#   just ROS_DISTRO=humble <recipe>
+export ROS_DISTRO := env_var_or_default('ROS_DISTRO', 'jazzy')
+
 # Default recipe - show available commands
 default:
     @just --list
@@ -101,7 +108,7 @@ test:
 # Run safety tests only (MUST pass before deployment)
 test-safety:
     docker-compose run --rm dev bash -c " \
-        source /opt/ros/jazzy/setup.bash && \
+        source /opt/ros/\$ROS_DISTRO/setup.bash && \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug && \
         source install/setup.bash && \
         colcon test --packages-select rmw_robotops --ctest-args -R test_safety && \
@@ -111,7 +118,7 @@ test-safety:
 # Run performance benchmarks
 benchmark:
     docker-compose run --rm dev bash -c " \
-        source /opt/ros/jazzy/setup.bash && \
+        source /opt/ros/\$ROS_DISTRO/setup.bash && \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
         source install/setup.bash && \
         ./install/rmw_robotops/lib/rmw_robotops/benchmark_latency \
@@ -120,7 +127,7 @@ benchmark:
 # Run stress test (10,000 msg/sec)
 stress:
     docker-compose run --rm dev bash -c " \
-        source /opt/ros/jazzy/setup.bash && \
+        source /opt/ros/\$ROS_DISTRO/setup.bash && \
         colcon build && \
         source install/setup.bash && \
         ros2 run rmw_robotops stress_test \
@@ -173,7 +180,7 @@ check-setup:
 ci-lint:
     #!/usr/bin/env bash
     echo "🔍 Running lint checks..."
-    source /opt/ros/jazzy/setup.bash
+    source /opt/ros/${ROS_DISTRO}/setup.bash
     cd /workspace
     colcon build --packages-select rmw_robotops
     colcon test --packages-select rmw_robotops --ctest-args -R lint
@@ -183,7 +190,7 @@ ci-lint:
 ci-test:
     #!/usr/bin/env bash
     echo "🧪 Running tests with sanitizers..."
-    source /opt/ros/jazzy/setup.bash
+    source /opt/ros/${ROS_DISTRO}/setup.bash
     cd /workspace
     colcon build --packages-select rmw_robotops \
       --cmake-args -DCMAKE_BUILD_TYPE=Debug \
@@ -196,7 +203,7 @@ ci-test:
 ci-benchmark:
     #!/usr/bin/env bash
     echo "📊 Running benchmarks..."
-    source /opt/ros/jazzy/setup.bash
+    source /opt/ros/${ROS_DISTRO}/setup.bash
     cd /workspace
     colcon build --packages-select rmw_robotops --cmake-args -DCMAKE_BUILD_TYPE=Release
     source /workspace/install/setup.bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         # Production: https://apt.robotops.com
         # Development: https://apt.development.robotops.com
         APT_REPO_URL: ${APT_REPO_URL:-https://apt.robotops.com}
+        # ROS distro: jazzy (Noble) | humble (Jammy/Jetson). See Dockerfile.
+        ROS_DISTRO: ${ROS_DISTRO:-jazzy}
     image: rmw_robotops:dev
     volumes:
       - .:/workspace/src/rmw_robotops
@@ -28,7 +30,7 @@ services:
   # Build service - builds the package
   build:
     extends: dev
-    command: bash -c "source /opt/ros/jazzy/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --event-handlers console_direct+"
+    command: bash -c "source /opt/ros/${ROS_DISTRO:-jazzy}/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --event-handlers console_direct+"
 
   # Test service - runs tests with sanitizers
   test:
@@ -40,6 +42,8 @@ services:
         # Production: https://apt.robotops.com
         # Development: https://apt.development.robotops.com
         APT_REPO_URL: ${APT_REPO_URL:-https://apt.robotops.com}
+        # ROS distro: jazzy (Noble) | humble (Jammy/Jetson). See Dockerfile.
+        ROS_DISTRO: ${ROS_DISTRO:-jazzy}
     image: rmw_robotops:test
     volumes:
       - .:/workspace/src/rmw_robotops
@@ -49,7 +53,7 @@ services:
       - ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1
       - UBSAN_OPTIONS=print_stacktrace=1
     working_dir: /workspace/src/rmw_robotops
-    command: bash -c "source /opt/ros/jazzy/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address -fsanitize=undefined' && source install/setup.bash && colcon test --event-handlers console_direct+ && colcon test-result --verbose"
+    command: bash -c "source /opt/ros/${ROS_DISTRO:-jazzy}/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address -fsanitize=undefined' && source install/setup.bash && colcon test --event-handlers console_direct+ && colcon test-result --verbose"
 
 volumes:
   build_cache:

--- a/package.xml
+++ b/package.xml
@@ -31,11 +31,16 @@
   <!-- ros2_tracing for LTTng tracepoint emission -->
   <depend>tracetools</depend>
 
-  <!-- FastDDS dependencies (can be swapped at runtime) -->
+  <!-- FastDDS dependencies (can be swapped at runtime).
+       No version floor: the underlying RMW is selected/loaded by library name
+       at runtime (see src/rmw_init.cpp) and CMake imposes no FastDDS version,
+       so these are plain deps. Pinning a floor here breaks Humble, which ships
+       older FastDDS than Jazzy (fastrtps 2.6.x / fastcdr 1.0.x vs Jazzy's
+       2.14.x / 2.x) — the old 2.10.0/2.2.0 floors were Jazzy-only (ROB-325). -->
   <depend>rmw_fastrtps_cpp</depend>
   <depend>rmw_fastrtps_shared_cpp</depend>
-  <depend version_gte="2.10.0">fastrtps</depend>
-  <depend version_gte="2.2.0">fastcdr</depend>
+  <depend>fastrtps</depend>
+  <depend>fastcdr</depend>
 
   <!-- YAML parsing for configuration -->
   <depend>yaml-cpp</depend>

--- a/src/rmw_stubs.cpp
+++ b/src/rmw_stubs.cpp
@@ -18,7 +18,21 @@
 #include <dlfcn.h>
 #include <cstdio>
 
-#include "rmw/dynamic_message_type_support.h"
+// Several RMW APIs forwarded by the stubs below were introduced in ROS 2 Iron
+// and are present on Jazzy, but do NOT exist on Humble's older rmw (6.1.x):
+//   - discovery options (rmw_discovery_options_t + init/equal/copy/fini)
+//   - dynamic message type support (rmw_take_dynamic_message* /
+//     rmw_serialization_support_init, via rosidl_dynamic_typesupport_* types)
+//   - the topic type-hash setter (rosidl_type_hash_t)
+// Probe for rmw/discovery_options.h (an Iron+ marker absent on Humble) to gate
+// all three regions and the dynamic-typesupport include, so this file compiles
+// unchanged on Jazzy while dropping the non-existent-on-Humble forwarders on
+// Humble. The underlying RMW on Humble lacks these symbols anyway, so the
+// dropped stubs would never have had anything to dlsym to. ROB-325.
+#if defined(__has_include) && __has_include("rmw/discovery_options.h")
+#  define RMW_ROBOTOPS_HAS_IRON_RMW_API 1
+#  include "rmw/dynamic_message_type_support.h"
+#endif
 #include "rmw/error_handling.h"
 #include "rmw/event.h"
 #include "rmw/features.h"
@@ -384,6 +398,7 @@ rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret_t rcutils_ret)
   return underlying_func(rcutils_ret);
 }
 
+#ifdef RMW_ROBOTOPS_HAS_IRON_RMW_API
 rmw_discovery_options_t
 rmw_get_zero_initialized_discovery_options(void)
 {
@@ -496,7 +511,9 @@ rmw_discovery_options_fini(rmw_discovery_options_t * discovery_options)
 
   return underlying_func(discovery_options);
 }
+#endif  // RMW_ROBOTOPS_HAS_IRON_RMW_API (discovery options)
 
+#ifdef RMW_ROBOTOPS_HAS_IRON_RMW_API
 rmw_ret_t
 rmw_take_dynamic_message(
   const rmw_subscription_t * subscription,
@@ -573,6 +590,7 @@ rmw_serialization_support_init(
 
   return underlying_func(serialization_lib_name, allocator, serialization_support);
 }
+#endif  // RMW_ROBOTOPS_HAS_IRON_RMW_API (dynamic message type support)
 
 rmw_event_t
 rmw_get_zero_initialized_event(void)
@@ -3280,6 +3298,7 @@ rmw_topic_endpoint_info_set_topic_type(
   return underlying_func(topic_endpoint_info, topic_type, allocator);
 }
 
+#ifdef RMW_ROBOTOPS_HAS_IRON_RMW_API
 rmw_ret_t
 rmw_topic_endpoint_info_set_topic_type_hash(
   rmw_topic_endpoint_info_t * topic_endpoint_info,
@@ -3303,6 +3322,7 @@ rmw_topic_endpoint_info_set_topic_type_hash(
 
   return underlying_func(topic_endpoint_info, type_hash);
 }
+#endif  // RMW_ROBOTOPS_HAS_IRON_RMW_API (topic type hash)
 
 rmw_ret_t
 rmw_topic_endpoint_info_set_node_name(


### PR DESCRIPTION
Promotes the Humble build (#64) to main so the v0.9.6 release can be dispatched. Adds ros-humble-rmw-robotops (jammy/arm64) — the last RobotOps ROS package to get a Humble build. After merge: dispatch release.yml on main.