### PR TITLE
release: rmw_robotops v0.9.7 — add Humble/amd64 build (ROB-402)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,10 @@ jobs:
             runner: ubuntu-24.04-arm
             ros_distro: humble
             os_version: jammy
+          - arch: amd64
+            runner: ubuntu-22.04
+            ros_distro: humble
+            os_version: jammy
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.7 (2026-06-16)
+-------------------
+
+* ``release.yml``: add an amd64 row to the Humble/jammy ``build-packages`` matrix (mirrors the existing humble/arm64 row) so ``ros-humble-rmw-robotops`` is published for amd64 in addition to arm64 (ROB-402). The build apt-installs the now-published ``ros-humble-robotops-msgs`` / ``ros-humble-robotops-config`` amd64 debs.
+
 0.9.6 (2026-05-29)
 -------------------
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.6</version>
+  <version>0.9.7</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
## ROB-402: publish Humble/amd64 ROS dependency debs

Adds an `amd64` row to the existing Humble/jammy `build-packages` matrix in `release.yml`, mirroring the existing humble/arm64 row, so `ros-humble-rmw-robotops` is published for amd64 (jammy ABI).

- `release.yml`: new matrix entry `arch: amd64 / runner: ubuntu-22.04 / ros_distro: humble / os_version: jammy`
- `package.xml`: version 0.9.6 → 0.9.7
- `CHANGELOG.rst`: 0.9.7 entry

Third of three repos (msgs ✅ → config ✅ → rmw). The humble/amd64 build apt-installs the now-published ros-humble-robotops-msgs (0.5.4) + ros-humble-robotops-config (0.9.8) amd64 debs. Lands on main via development per repo convention.