### PR TITLE
fix(rob-403): stop typesupport error spam from C++ nodes under rmw_robotops

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.9.8 (2026-06-21)
+-------------------
+
+* Fix service/subscription typesupport error spam at node startup (ROB-403). Every C++ (rclcpp) node printed ``Handle's typesupport identifier (rosidl_typesupport_cpp) is not supported by this library ... / service's implementation is invalid`` repeatedly. Root cause: ``store_subscription_metadata`` / ``store_publisher_metadata`` probed only the ``rosidl_typesupport_introspection_c`` identifier when resolving introspection members. For C++ nodes the message type support wrapper is ``rosidl_typesupport_cpp`` (whose map holds the ``_cpp`` introspection variant), so the lookup missed and ``get_message_typesupport_handle`` set a thread-local rcutils error that rmw_robotops never reset — the next rcutils consumer on that thread then tripped the "error state is being overwritten" guard and dumped the message to stderr. Services and topics were never functionally broken (the original type support handle is forwarded unchanged to the underlying RMW), but the noise was alarming and the introspection metadata (type name, content hash for dedup) was silently dropped for all C++ publishers/subscribers.
+* New shared helper ``rmw_robotops::resolve_introspection_members()`` resolves the introspection ``MessageMembers`` from either a C or C++ wrapper handle (probes ``_c`` then ``_cpp``) and always calls ``rcutils_reset_error()`` after an expected miss, so no stale error escapes. Both the publisher and subscription metadata paths now use it, which also restores tracing metadata for C++ nodes.
+
 0.9.7 (2026-06-16)
 -------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(std_msgs REQUIRED)
+  find_package(rosidl_runtime_cpp REQUIRED)
+  find_package(rosidl_typesupport_cpp REQUIRED)
 
   # Linting - Manual configuration to exclude ament_copyright
   # Note: ament_copyright doesn't support custom copyright holders like "Robot Ops Inc."
@@ -181,6 +183,16 @@ if(BUILD_TESTING)
     test/test_metadata_extraction.cpp
   )
   target_link_libraries(test_metadata_extraction ${PROJECT_NAME})
+  ament_target_dependencies(test_metadata_extraction
+    rmw
+    rcutils
+    robotops_msgs
+    rosidl_runtime_c
+    rosidl_runtime_cpp
+    rosidl_typesupport_cpp
+    rosidl_typesupport_introspection_c
+    std_msgs
+  )
 
   # Pub/sub tracing integration test
   ament_add_gtest(test_pubsub_tracing

--- a/include/rmw_robotops/utils.hpp
+++ b/include/rmw_robotops/utils.hpp
@@ -26,6 +26,9 @@ struct rosidl_typesupport_introspection_c__MessageMembers_s;
 typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
   rosidl_typesupport_introspection_c__MessageMembers;
 
+// Forward declaration for the message type support handle (defined in rosidl_runtime_c).
+struct rosidl_message_type_support_t;
+
 namespace rmw_robotops
 {
 
@@ -83,6 +86,34 @@ uint64_t compute_content_hash(const void * data, size_t size) noexcept;
 uint64_t compute_message_hash(
   const void * ros_message,
   const rosidl_typesupport_introspection_c__MessageMembers * members) noexcept;
+
+/// Resolve the introspection MessageMembers from an arbitrary message type support handle.
+///
+/// rcl/rclcpp/rclc hand the RMW the top-level "wrapper" type support handle whose
+/// `typesupport_identifier` is one of `rosidl_typesupport_c` (C nodes) or
+/// `rosidl_typesupport_cpp` (C++ nodes). The introspection members we need for tracing
+/// metadata (type name, content hashing) live under a serialization-specific sub-handle:
+/// `rosidl_typesupport_introspection_c` for C wrappers and
+/// `rosidl_typesupport_introspection_cpp` for C++ wrappers.
+///
+/// `get_message_typesupport_handle()` only matches one identifier at a time and, on a
+/// miss, sets the thread-local rcutils error state
+/// ("Handle's typesupport identifier (...) is not supported by this library"). If that
+/// stale error is left in place, the *next* rcutils consumer in the same thread trips the
+/// "This error state is being overwritten" guard and spams stderr (ROB-403). Worse, only
+/// probing the `_c` identifier means C++ nodes never resolve their members at all, so
+/// tracing metadata was silently dropped for every C++ publisher/subscriber.
+///
+/// This helper probes `_c` first, then `_cpp`, and ALWAYS calls `rcutils_reset_error()`
+/// after a miss so no stale error escapes. The C and C++ introspection `MessageMembers`
+/// structs are layout-compatible, so the returned pointer is always reinterpreted as the
+/// `_c` struct (matching the rest of the hashing code).
+///
+/// @param type_support Top-level message type support handle from rcl (may be null)
+/// @return Introspection members pointer, or nullptr if neither variant resolves
+const rosidl_typesupport_introspection_c__MessageMembers *
+resolve_introspection_members(
+  const rosidl_message_type_support_t * type_support) noexcept;
 
 /// Detect action event type from topic name
 /// @param topic_name ROS topic name

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.7</version>
+  <version>0.9.8</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/src/rmw_publisher.cpp
+++ b/src/rmw_publisher.cpp
@@ -28,7 +28,6 @@
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
-#include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 
 // LTTng tracepoints (optional - gracefully degrades if not available)
@@ -90,30 +89,22 @@ void store_publisher_metadata(
     std::memcpy(metadata.node_namespace, node->namespace_, ns_len);
     metadata.node_namespace[ns_len] = '\0';
 
-    // Store message type name and introspection members from type support
+    // Store message type name and introspection members from type support.
+    // resolve_introspection_members() handles both C and C++ wrapper handles and resets
+    // the rcutils error state on an expected lookup miss (ROB-403).
     metadata.members = nullptr;
-    if (type_support != nullptr && type_support->data != nullptr) {
-      // Extract type name from type support (e.g., "std_msgs/msg/String")
-      const rosidl_message_type_support_t * ts =
-        get_message_typesupport_handle(
-          type_support,
-          rosidl_typesupport_introspection_c__identifier);
-
-      if (ts != nullptr) {
-        const auto * members =
-          static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
-        if (members != nullptr) {
-          // Format: "package_name/msg/MessageName"
-          snprintf(
-            metadata.message_type,
-            MAX_MESSAGE_TYPE_LENGTH,
-            "%s/%s",
-            members->message_namespace_,
-            members->message_name_);
-          // Cache members pointer for content hashing
-          metadata.members = members;
-        }
-      }
+    const rosidl_typesupport_introspection_c__MessageMembers * members =
+      rmw_robotops::resolve_introspection_members(type_support);
+    if (members != nullptr) {
+      // Format: "package_name/msg/MessageName"
+      snprintf(
+        metadata.message_type,
+        MAX_MESSAGE_TYPE_LENGTH,
+        "%s/%s",
+        members->message_namespace_,
+        members->message_name_);
+      // Cache members pointer for content hashing
+      metadata.members = members;
     }
 
     // Store in cache (with mutex protection)

--- a/src/rmw_subscription.cpp
+++ b/src/rmw_subscription.cpp
@@ -28,7 +28,6 @@
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
-#include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 
 // LTTng tracepoints (optional - gracefully degrades if not available)
@@ -88,28 +87,21 @@ void store_subscription_metadata(
     std::memcpy(metadata.node_namespace, node->namespace_, ns_len);
     metadata.node_namespace[ns_len] = '\0';
 
-    // Store message type name and introspection members from type support
+    // Store message type name and introspection members from type support.
+    // resolve_introspection_members() handles both C and C++ wrapper handles and resets
+    // the rcutils error state on an expected lookup miss (ROB-403).
     metadata.members = nullptr;
-    if (type_support != nullptr && type_support->data != nullptr) {
-      const rosidl_message_type_support_t * ts =
-        get_message_typesupport_handle(
-          type_support,
-          rosidl_typesupport_introspection_c__identifier);
-
-      if (ts != nullptr) {
-        const auto * members =
-          static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
-        if (members != nullptr) {
-          snprintf(
-            metadata.message_type,
-            MAX_MESSAGE_TYPE_LENGTH,
-            "%s/%s",
-            members->message_namespace_,
-            members->message_name_);
-          // Cache members pointer for content hashing
-          metadata.members = members;
-        }
-      }
+    const rosidl_typesupport_introspection_c__MessageMembers * members =
+      rmw_robotops::resolve_introspection_members(type_support);
+    if (members != nullptr) {
+      snprintf(
+        metadata.message_type,
+        MAX_MESSAGE_TYPE_LENGTH,
+        "%s/%s",
+        members->message_namespace_,
+        members->message_name_);
+      // Cache members pointer for content hashing
+      metadata.members = members;
     }
 
     // Store in cache

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,16 +14,20 @@
 
 #include "rmw_robotops/utils.hpp"
 
+#include <rcutils/error_handling.h>
 #include <rcutils/logging_macros.h>
 #include <xxhash.h>
 
 #include <cstring>
 
 #include "robotops_msgs/msg/trace_event.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
 #include "rosidl_runtime_c/string.h"
 #include "rosidl_runtime_c/primitives_sequence.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/field_types.h"
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
 
 namespace rmw_robotops
 {
@@ -38,6 +42,39 @@ uint64_t compute_content_hash(const void * data, size_t size) noexcept
   // XXH3 is the latest generation - optimized for both small and large inputs
   // Performance: 2-5x faster than FNV-1a with better collision resistance
   return XXH3_64bits(data, size);
+}
+
+const rosidl_typesupport_introspection_c__MessageMembers *
+resolve_introspection_members(
+  const rosidl_message_type_support_t * type_support) noexcept
+{
+  if (type_support == nullptr || type_support->data == nullptr) {
+    return nullptr;
+  }
+
+  // Probe the C introspection identifier first (C / rclc nodes).
+  const rosidl_message_type_support_t * ts =
+    get_message_typesupport_handle(
+    type_support, rosidl_typesupport_introspection_c__identifier);
+  if (ts == nullptr) {
+    // Expected miss for C++ nodes: clear the stale error state before the next probe
+    // so it cannot trip rcutils' "error state is being overwritten" guard (ROB-403).
+    rcutils_reset_error();
+
+    // Probe the C++ introspection identifier (rclcpp nodes).
+    ts = get_message_typesupport_handle(
+      type_support, rosidl_typesupport_introspection_cpp::typesupport_identifier);
+    if (ts == nullptr) {
+      // Neither variant resolved (e.g. a wrapper without introspection support).
+      // Clear the error so nothing downstream inherits it; metadata is simply skipped.
+      rcutils_reset_error();
+      return nullptr;
+    }
+  }
+
+  // The C and C++ introspection MessageMembers structs are layout-compatible, so the
+  // C++ handle's data can be reinterpreted as the C struct used throughout the hashing code.
+  return static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
 }
 
 /// Hash a single field using introspection

--- a/test/test_metadata_extraction.cpp
+++ b/test/test_metadata_extraction.cpp
@@ -16,9 +16,14 @@
 
 #include <cstring>
 
+#include "rcutils/error_handling.h"
 #include "rmw_robotops/span_id_generator.hpp"
 #include "rmw_robotops/trace_context.hpp"
 #include "rmw_robotops/trace_event_queue.hpp"
+#include "rmw_robotops/utils.hpp"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "std_msgs/msg/string.hpp"
 
 using rmw_robotops::generate_span_id;
 using rmw_robotops::generate_trace_id;
@@ -152,4 +157,44 @@ TEST(MetadataExtractionTest, MetadataFieldsHaveCorrectLengths) {
   event.message_type[MAX_MESSAGE_TYPE_LENGTH - 1] = '\0';
 
   EXPECT_EQ(MAX_MESSAGE_TYPE_LENGTH - 1, std::strlen(event.message_type));
+}
+
+// --- resolve_introspection_members() (ROB-403) ---------------------------------------
+//
+// These tests verify that the introspection-members resolver works for the C++ wrapper
+// handle that rclcpp nodes hand the RMW, AND that it never leaves a stale rcutils error
+// state behind. The stale-error leak was the root cause of the
+// "Handle's typesupport identifier (rosidl_typesupport_cpp) is not supported ...
+//  / service's implementation is invalid" log spam seen on real robots.
+
+using rmw_robotops::resolve_introspection_members;
+
+TEST(IntrospectionResolveTest, ResolvesCppTypeSupportHandle) {
+  // This is exactly the handle a C++ (rclcpp) node passes to rmw_create_subscription:
+  // identifier == "rosidl_typesupport_cpp", whose map contains introspection_cpp (not _c).
+  const rosidl_message_type_support_t * cpp_handle =
+    rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
+  ASSERT_NE(nullptr, cpp_handle);
+
+  rcutils_reset_error();
+  const rosidl_typesupport_introspection_c__MessageMembers * members =
+    resolve_introspection_members(cpp_handle);
+
+  // Before the fix this returned nullptr for C++ nodes (only the _c id was probed),
+  // so C++ publishers/subscribers got no tracing type metadata at all.
+  ASSERT_NE(nullptr, members);
+  EXPECT_STREQ("String", members->message_name_);
+  // The C++ introspection variant reports the namespace with C++ scoping ("std_msgs::msg");
+  // the C variant reports "std_msgs". We only require that resolution succeeded.
+  ASSERT_NE(nullptr, members->message_namespace_);
+  EXPECT_NE(nullptr, std::strstr(members->message_namespace_, "std_msgs"));
+
+  // Critical: no stale rcutils error may be left behind for the next thread-local consumer.
+  EXPECT_FALSE(rcutils_error_is_set());
+}
+
+TEST(IntrospectionResolveTest, NullHandleIsSafeAndLeavesNoError) {
+  rcutils_reset_error();
+  EXPECT_EQ(nullptr, resolve_introspection_members(nullptr));
+  EXPECT_FALSE(rcutils_error_is_set());
 }


### PR DESCRIPTION
## Summary

Fixes the startup error spam reported on real robots (ROS 2 Jazzy, `RMW_IMPLEMENTATION=rmw_robotops` wrapping `rmw_fastrtps_cpp`). Every C++ (rclcpp) node — robot_state_publisher, move_group, ros2_control, xarm_planner — printed, repeatedly:

```
Handle's typesupport identifier (rosidl_typesupport_cpp) is not supported by this library, at ./src/type_support_dispatch.hpp:114
  / service's implementation is invalid, at ./src/rcl/service.c:427
```

## Root cause (it is NOT the service path)

The symptom names "service", but the leak originates in rmw_robotops' own tracing-metadata code on the **subscription/publisher** path.

`store_subscription_metadata()` / `store_publisher_metadata()` resolved introspection members by probing **only** `rosidl_typesupport_introspection_c`. For C++ nodes the message type support wrapper is `rosidl_typesupport_cpp`, whose map holds the `_cpp` introspection variant — so the `_c` lookup misses and `get_message_typesupport_handle()` sets a thread-local rcutils error that rmw_robotops never reset. The next rcutils consumer on that thread (`rcl_service_is_valid` during `NodeTypeDescriptions` setup) then trips the "error state is being overwritten" guard and dumps both messages to stderr.

Confirmed via gdb backtrace: the un-reset `SET` comes from `store_subscription_metadata` (ParameterEvent subscription), immediately followed by `rcl_service_is_valid` overwriting it.

## Functional impact

Services and topics were **never broken** — rmw_robotops forwards the original type support handle unchanged to the underlying RMW, which resolves it correctly (verified: `add_two_ints` service call returns the correct result). The spam was pure noise. Separately, introspection metadata (type name, content hash for dedup) was being silently dropped for **all C++ publishers/subscribers** because only the `_c` identifier was ever tried — this fix restores it.

## Fix

New shared helper `rmw_robotops::resolve_introspection_members()` probes `_c` then `_cpp` and always calls `rcutils_reset_error()` after an expected miss. Both metadata paths use it. The C and C++ introspection `MessageMembers` structs are layout-compatible, so the `_cpp` handle's data is reinterpreted as the `_c` struct used by the existing hashing code.

## Validation (ROS 2 Jazzy + rmw_fastrtps_cpp)

| Scenario | Before | After |
|---|---|---|
| `demo_nodes_cpp add_two_ints` server+client under rmw_robotops | 1 typesupport error + 1 overwrite warning each on server AND client; service call OK | **0 errors, 0 warnings**; service call OK (Result: 5) |
| Same under bare `rmw_fastrtps_cpp` (control) | clean | clean |
| gtest + lint suite | 68 gtest pass | **70 gtest pass** (+2 resolver tests), cpplint/uncrustify clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)