### PR TITLE
rosdep: distro-aware keys (jammy->humble, noble->jazzy)

### DIFF
--- a/rosdep/robotops.yaml
+++ b/rosdep/robotops.yaml
@@ -1,11 +1,17 @@
+# Distro-aware keys: rosdep resolves by Ubuntu codename, so Jammy (Humble) and
+# Noble (Jazzy) each map to their matching ros-<distro>-* package. Both sets are
+# published on apt.robotops.com for amd64 + arm64.
 rmw_robotops:
   ubuntu:
-    - ros-jazzy-rmw-robotops
+    jammy: [ros-humble-rmw-robotops]
+    noble: [ros-jazzy-rmw-robotops]
 
 robotops-config:
   ubuntu:
-    - ros-jazzy-robotops-config
+    jammy: [ros-humble-robotops-config]
+    noble: [ros-jazzy-robotops-config]
 
 robotops_msgs:
   ubuntu:
-    - ros-jazzy-robotops-msgs
+    jammy: [ros-humble-robotops-msgs]
+    noble: [ros-jazzy-robotops-msgs]


### PR DESCRIPTION
The rosdep keys hardcoded `ros-jazzy-*` for all Ubuntu versions, so `rosdep install` on Jammy/Humble resolved the wrong (jazzy) packages — breaking the ament/rosdep acquisition path on Humble. Map by Ubuntu codename instead.

Verified both package sets are published on apt.robotops.com for amd64 + arm64. Unblocks the ament/rosdep install path documented in RobotOpsInc/web_app#204.