### PR TITLE
release: rmw_robotops 0.10.0 (service/action stitching, ROB-406)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.10.0 (2026-06-23)
+-------------------
+
+* Service/action span stitching (ROB-406): ``rmw_service`` / ``rmw_client`` compute a request/response payload ``content_hash`` and emit a producer/consumer ``direction``, so the agent correlates RPC spans into one distributed trace instead of minting a fresh root span per service/action call.
+
 0.9.9 (2026-06-21)
 -------------------
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.9</version>
+  <version>0.10.0</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.


### PR DESCRIPTION
Version bump for the prod release of the ROB-405 trace-fidelity work (the prior version was already prod-released without it). Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4