### PR TITLE
release: promote rmw_robotops to main (ROB-405 trace fidelity)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rmw_robotops
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.10.0 (2026-06-23)
+-------------------
+
+* Service/action span stitching (ROB-406): ``rmw_service`` / ``rmw_client`` compute a request/response payload ``content_hash`` and emit a producer/consumer ``direction``, so the agent correlates RPC spans into one distributed trace instead of minting a fresh root span per service/action call.
+
 0.9.9 (2026-06-21)
 -------------------
 

--- a/include/rmw_robotops/trace_event_queue.hpp
+++ b/include/rmw_robotops/trace_event_queue.hpp
@@ -101,6 +101,17 @@ struct TraceEvent
   // It's now the primary/only correlation method (content-based via introspection)
   uint8_t correlation_method;  // From robotops_msgs TraceEvent constants
 
+  // Producer-vs-consumer direction for request/response-style events (ROB-406).
+  // For services/actions the same event_type is emitted on both ends of the RPC
+  // (client send_request and server take_request are both EVENT_SERVICE_REQUEST),
+  // so the agent's CorrelationEngine needs this to tell who SEEDS the window
+  // (producer) from who CORRELATES against it (consumer).
+  // Values match robotops_msgs::msg::TraceEvent::DIRECTION_* constants:
+  //   0 = DIRECTION_UNSPECIFIED (pub/sub: direction implicit in event_type)
+  //   1 = DIRECTION_PRODUCER    (client send_request / send_response)
+  //   2 = DIRECTION_CONSUMER    (service take_request / client take_response)
+  uint8_t direction;
+
   // Legacy operation field (deprecated, use event_type instead)
   OperationType operation;
 
@@ -115,6 +126,7 @@ struct TraceEvent
     message_size_bytes(0),
     dds_domain_id(0),
     correlation_method(0),
+    direction(0),
     operation(OP_PUBLISH)
   {
     trace_id[0] = '\0';

--- a/include/rmw_robotops/utils.hpp
+++ b/include/rmw_robotops/utils.hpp
@@ -28,6 +28,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
 
 // Forward declaration for the message type support handle (defined in rosidl_runtime_c).
 struct rosidl_message_type_support_t;
+// Forward declaration for service type support (defined in rosidl_runtime_c)
+struct rosidl_service_type_support_t;
 
 namespace rmw_robotops
 {
@@ -114,6 +116,25 @@ uint64_t compute_message_hash(
 const rosidl_typesupport_introspection_c__MessageMembers *
 resolve_introspection_members(
   const rosidl_message_type_support_t * type_support) noexcept;
+
+/// Extract the introspection members for a service's REQUEST payload (ROB-406).
+/// @param service_type_support The `rosidl_service_type_support_t *` handed to
+///        rmw_create_service / rmw_create_client (passed as void* to keep this
+///        header free of rosidl service headers).
+/// @return Pointer to the request `MessageMembers`, or nullptr if the
+///         introspection typesupport is unavailable.
+///
+/// @note Used so the client-send and service-take paths can compute a
+///       `content_hash` of the request payload that MATCHES on both ends — the
+///       same correlation scheme the pub/sub paths use. The two ends serialize
+///       byte-identical request payloads, so the FNV-1a hash agrees.
+const rosidl_typesupport_introspection_c__MessageMembers *
+get_service_request_members(const void * service_type_support) noexcept;
+
+/// Extract the introspection members for a service's RESPONSE payload (ROB-406).
+/// @see get_service_request_members
+const rosidl_typesupport_introspection_c__MessageMembers *
+get_service_response_members(const void * service_type_support) noexcept;
 
 /// Detect action event type from topic name
 /// @param topic_name ROS topic name

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_robotops</name>
-  <version>0.9.9</version>
+  <version>0.10.0</version>
   <description>
     ROS2 RMW implementation that wraps underlying RMW (atop various DDS implementations: FastDDS, CycloneDDS, etc.)
     to add distributed tracing capabilities with OpenTelemetry context propagation.

--- a/src/rmw_client.cpp
+++ b/src/rmw_client.cpp
@@ -61,6 +61,10 @@ struct ClientMetadata
   char node_name[MAX_NODE_NAME_LENGTH];
   char node_namespace[MAX_NODE_NAME_LENGTH];
   char service_name[MAX_TOPIC_NAME_LENGTH];  // Services use same length as topics
+  // Cached introspection members for content hashing (ROB-406). nullptr if the
+  // service's package was built without rosidl_typesupport_introspection_c.
+  const rosidl_typesupport_introspection_c__MessageMembers * request_members;
+  const rosidl_typesupport_introspection_c__MessageMembers * response_members;
 };
 
 /// Pending request context (for response correlation)
@@ -83,6 +87,7 @@ std::mutex pending_requests_mutex;
 void store_client_metadata(
   const rmw_client_t * client,
   const rmw_node_t * node,
+  const rosidl_service_type_support_t * type_support,
   const char * service_name) noexcept
 {
   try {
@@ -99,6 +104,12 @@ void store_client_metadata(
     size_t svc_len = std::min(std::strlen(service_name), MAX_TOPIC_NAME_LENGTH - 1);
     std::memcpy(metadata.service_name, service_name, svc_len);
     metadata.service_name[svc_len] = '\0';
+
+    // Cache introspection members for content hashing (ROB-406)
+    metadata.request_members =
+      rmw_robotops::get_service_request_members(type_support);
+    metadata.response_members =
+      rmw_robotops::get_service_response_members(type_support);
 
     std::lock_guard<std::mutex> lock(client_metadata_mutex);
     client_metadata_cache[client] = metadata;
@@ -158,7 +169,7 @@ rmw_create_client(
 
   // Store metadata for later use
   if (client != nullptr) {
-    store_client_metadata(client, node, service_name);
+    store_client_metadata(client, node, type_support, service_name);
   }
 
   return client;
@@ -266,16 +277,29 @@ rmw_send_request(
       event.parent_span_id[sizeof(event.parent_span_id) - 1] = '\0';
 
       event.dds_domain_id = get_dds_domain_id();
+      // ROB-406: content-hash correlation. This client send_request is the
+      // PRODUCER end of the request leg; the service's rmw_take_request
+      // (CONSUMER) correlates against it by the request payload's content_hash.
       event.correlation_method =
-        robotops_msgs__msg__TraceEvent__CORRELATION_FASTDDS_SEQUENCE;
+        robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+      event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_PRODUCER;
 
       if (sequence_id != nullptr) {
         event.sequence_number = static_cast<uint64_t>(*sequence_id);
       }
+      // Seed the correlation timestamp bucket with this send time so the
+      // service-take (which uses the DDS source_timestamp of the same sample)
+      // buckets together.
+      event.source_timestamp_ns = static_cast<int64_t>(start_timestamp_ns);
 
       // Get client metadata
       ClientMetadata metadata;
       if (get_client_metadata(client, metadata)) {
+        if (metadata.request_members != nullptr) {
+          event.content_hash = rmw_robotops::compute_message_hash(
+            ros_request, metadata.request_members);
+        }
+
         size_t svc_len = std::min(std::strlen(metadata.service_name),
             sizeof(event.topic_or_service) - 1);
         std::memcpy(event.topic_or_service, metadata.service_name, svc_len);
@@ -408,16 +432,30 @@ rmw_take_response(
       event.parent_span_id[sizeof(event.parent_span_id) - 1] = '\0';
 
       event.dds_domain_id = get_dds_domain_id();
+      // ROB-406: this client take_response is the CONSUMER end of the response
+      // leg. The client's local trace is already continued via the
+      // sequence_id-keyed pending-request lookup above (intra-process), so we
+      // keep that trace_id/parent. We additionally tag direction + content_hash
+      // so the response leg can be cross-process correlated to the server's
+      // send_response in a later phase; for Phase 1 it is informational.
       event.correlation_method =
-        robotops_msgs__msg__TraceEvent__CORRELATION_FASTDDS_SEQUENCE;
+        robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+      event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_CONSUMER;
 
       if (request_header != nullptr) {
         event.sequence_number = request_header->request_id.sequence_number;
+        event.source_timestamp_ns =
+          static_cast<int64_t>(request_header->source_timestamp);
       }
 
       // Get client metadata
       ClientMetadata metadata;
       if (get_client_metadata(client, metadata)) {
+        if (metadata.response_members != nullptr) {
+          event.content_hash = rmw_robotops::compute_message_hash(
+            ros_response, metadata.response_members);
+        }
+
         size_t svc_len = std::min(std::strlen(metadata.service_name),
             sizeof(event.topic_or_service) - 1);
         std::memcpy(event.topic_or_service, metadata.service_name, svc_len);

--- a/src/rmw_service.cpp
+++ b/src/rmw_service.cpp
@@ -27,6 +27,7 @@
 #include "rmw_robotops/trace_event_queue.hpp"
 #include "rmw_robotops/utils.hpp"
 #include "robotops_msgs/msg/trace_event.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
 
 // LTTng tracepoints (optional)
 #ifdef ROS_TRACING_ENABLED
@@ -59,6 +60,10 @@ struct ServiceMetadata
   char node_name[MAX_NODE_NAME_LENGTH];
   char node_namespace[MAX_NODE_NAME_LENGTH];
   char service_name[MAX_TOPIC_NAME_LENGTH];  // Services use same length as topics
+  // Cached introspection members for content hashing (ROB-406). nullptr if the
+  // service's package was built without rosidl_typesupport_introspection_c.
+  const rosidl_typesupport_introspection_c__MessageMembers * request_members;
+  const rosidl_typesupport_introspection_c__MessageMembers * response_members;
 };
 
 /// Cache of service metadata
@@ -69,6 +74,7 @@ std::mutex service_metadata_mutex;
 void store_service_metadata(
   const rmw_service_t * service,
   const rmw_node_t * node,
+  const rosidl_service_type_support_t * type_support,
   const char * service_name) noexcept
 {
   try {
@@ -85,6 +91,12 @@ void store_service_metadata(
     size_t svc_len = std::min(std::strlen(service_name), MAX_TOPIC_NAME_LENGTH - 1);
     std::memcpy(metadata.service_name, service_name, svc_len);
     metadata.service_name[svc_len] = '\0';
+
+    // Cache introspection members for content hashing (ROB-406)
+    metadata.request_members =
+      rmw_robotops::get_service_request_members(type_support);
+    metadata.response_members =
+      rmw_robotops::get_service_response_members(type_support);
 
     std::lock_guard<std::mutex> lock(service_metadata_mutex);
     service_metadata_cache[service] = metadata;
@@ -144,7 +156,7 @@ rmw_create_service(
 
   // Store metadata for later use
   if (service != nullptr) {
-    store_service_metadata(service, node, service_name);
+    store_service_metadata(service, node, type_support, service_name);
   }
 
   return service;
@@ -210,16 +222,23 @@ rmw_take_request(
   // STEP 3: Emit END event and set trace context
   if (ret == RMW_RET_OK && *taken && tracing_active) {
     try {
-      // Mint new trace for service request (start of new trace)
-      // Note: We cannot extract trace context from DDS for services because
-      // related_sample_identity is reserved for DDS-RPC request-response correlation
+      // ROB-406: Do NOT mint a fresh trace_id here. Previously this path minted
+      // a new root trace on every service take, guaranteeing every service
+      // request rendered as a separate root span. Instead we leave trace_id and
+      // parent_span_id EMPTY and emit a CONSUMER-direction content_hash so the
+      // agent's CorrelationEngine can rewrite them to the client-send's trace —
+      // exactly mirroring how the subscribe (rmw_take_with_info) path works.
+      //
+      // The local thread context still carries this span_id (with an empty
+      // trace_id) so rmw_send_response on the same thread pairs its RESPONSE
+      // event to this REQUEST via the shared span_id.
       TraceContext new_context;
-      rmw_robotops::generate_trace_id(new_context.trace_id);
+      new_context.trace_id[0] = '\0';  // Filled in by the agent on correlation
 
       std::memcpy(new_context.span_id, span_id_buf, sizeof(new_context.span_id) - 1);
       new_context.span_id[sizeof(new_context.span_id) - 1] = '\0';
 
-      new_context.parent_span_id[0] = '\0';  // Root span
+      new_context.parent_span_id[0] = '\0';
 
       set_trace_context(new_context);
 
@@ -227,31 +246,50 @@ rmw_take_request(
       tracepoint(robotops, take_request_end, ros_request, new_context.trace_id, span_id_buf);
       #endif
 
+      // Compute content hash of the REQUEST payload for cross-process
+      // correlation. The client-send hashes the byte-identical request, so the
+      // two hashes agree and the engine can match them (ROB-406).
+      uint64_t content_hash = 0;
+      uint32_t domain_id = get_dds_domain_id();
+
       // Emit service request TraceEvent
       TraceEvent event;
       event.timestamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
       event.event_type = robotops_msgs__msg__TraceEvent__EVENT_SERVICE_REQUEST;
 
-      std::memcpy(event.trace_id, new_context.trace_id, sizeof(event.trace_id) - 1);
-      event.trace_id[sizeof(event.trace_id) - 1] = '\0';
+      event.trace_id[0] = '\0';        // Empty → agent correlates (ROB-406)
+      event.parent_span_id[0] = '\0';  // Empty → agent correlates (ROB-406)
 
       std::memcpy(event.span_id, span_id_buf, sizeof(event.span_id) - 1);
       event.span_id[sizeof(event.span_id) - 1] = '\0';
 
-      event.parent_span_id[0] = '\0';  // Root span
-
-      event.dds_domain_id = get_dds_domain_id();
+      event.dds_domain_id = domain_id;
+      // Content-hash correlation (the v0.3.0 scheme), now applied to services.
       event.correlation_method =
-        robotops_msgs__msg__TraceEvent__CORRELATION_FASTDDS_SEQUENCE;
+        robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+      // This is the CONSUMER end of the RPC: it correlates against the client.
+      event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_CONSUMER;
+      // publisher_gid intentionally left empty: services share no DDS GID, so
+      // both client-send and service-take emit "" and the key matches on
+      // (service_name, content_hash, timestamp_bucket).
 
       if (request_header != nullptr) {
         event.sequence_number = request_header->request_id.sequence_number;
+        // source_timestamp_ns seeds the correlation timestamp bucket; use the
+        // DDS-provided source timestamp so client and server bucket together.
+        event.source_timestamp_ns =
+          static_cast<int64_t>(request_header->source_timestamp);
       }
 
       // Get service metadata
       ServiceMetadata metadata;
       if (get_service_metadata(service, metadata)) {
+        if (metadata.request_members != nullptr) {
+          content_hash = rmw_robotops::compute_message_hash(
+            ros_request, metadata.request_members);
+        }
+        event.content_hash = content_hash;
         size_t svc_len = std::min(std::strlen(metadata.service_name),
             sizeof(event.topic_or_service) - 1);
         std::memcpy(event.topic_or_service, metadata.service_name, svc_len);
@@ -379,8 +417,12 @@ rmw_send_response(
       event.parent_span_id[sizeof(event.parent_span_id) - 1] = '\0';
 
       event.dds_domain_id = get_dds_domain_id();
+      // ROB-406: content-hash correlation. This RESPONSE is the PRODUCER end of
+      // the response leg — the client's rmw_take_response (CONSUMER) correlates
+      // against it by the response payload's content_hash.
       event.correlation_method =
-        robotops_msgs__msg__TraceEvent__CORRELATION_FASTDDS_SEQUENCE;
+        robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+      event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_PRODUCER;
 
       if (request_header != nullptr) {
         event.sequence_number = request_header->sequence_number;
@@ -389,6 +431,11 @@ rmw_send_response(
       // Get service metadata
       ServiceMetadata metadata;
       if (get_service_metadata(service, metadata)) {
+        if (metadata.response_members != nullptr) {
+          event.content_hash = rmw_robotops::compute_message_hash(
+            ros_response, metadata.response_members);
+        }
+
         size_t svc_len = std::min(std::strlen(metadata.service_name),
             sizeof(event.topic_or_service) - 1);
         std::memcpy(event.topic_or_service, metadata.service_name, svc_len);

--- a/src/trace_publisher.cpp
+++ b/src/trace_publisher.cpp
@@ -102,6 +102,9 @@ bool convert_to_ros_message(
     msg.dds_domain_id = event.dds_domain_id;
     msg.correlation_method = event.correlation_method;
 
+    // Producer-vs-consumer direction for service/action RPC events (ROB-406)
+    msg.direction = event.direction;
+
     return true;
   } catch (...) {
     // Safety guarantee: Never propagate exceptions

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,10 +24,12 @@
 #include "rosidl_runtime_c/message_type_support_struct.h"
 #include "rosidl_runtime_c/string.h"
 #include "rosidl_runtime_c/primitives_sequence.h"
-#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
 #include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 #include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_c/service_introspection.h"
 
 namespace rmw_robotops
 {
@@ -322,6 +324,49 @@ uint64_t compute_message_hash(
     RCUTILS_LOG_ERROR_NAMED("rmw_robotops", "Exception in compute_message_hash");
     return 0;
   }
+}
+
+/// Resolve the introspection ServiceMembers from a service type support handle.
+/// Returns nullptr if the introspection typesupport is unavailable (e.g. a
+/// package built without rosidl_typesupport_introspection_c).
+static const rosidl_typesupport_introspection_c__ServiceMembers *
+get_service_members(const void * service_type_support) noexcept
+{
+  try {
+    if (service_type_support == nullptr) {
+      return nullptr;
+    }
+    const auto * ts_handle =
+      static_cast<const rosidl_service_type_support_t *>(service_type_support);
+
+    const rosidl_service_type_support_t * ts =
+      get_service_typesupport_handle(
+        ts_handle,
+        rosidl_typesupport_introspection_c__identifier);
+
+    if (ts == nullptr || ts->data == nullptr) {
+      return nullptr;
+    }
+    return static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(ts->data);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+const rosidl_typesupport_introspection_c__MessageMembers *
+get_service_request_members(const void * service_type_support) noexcept
+{
+  const rosidl_typesupport_introspection_c__ServiceMembers * members =
+    get_service_members(service_type_support);
+  return members != nullptr ? members->request_members_ : nullptr;
+}
+
+const rosidl_typesupport_introspection_c__MessageMembers *
+get_service_response_members(const void * service_type_support) noexcept
+{
+  const rosidl_typesupport_introspection_c__ServiceMembers * members =
+    get_service_members(service_type_support);
+  return members != nullptr ? members->response_members_ : nullptr;
 }
 
 /// Helper: Check if string ends with suffix

--- a/test/test_service_tracing.cpp
+++ b/test/test_service_tracing.cpp
@@ -134,21 +134,80 @@ TEST_F(ServiceTracingTest, ServiceResponseEventStructure) {
   EXPECT_STREQ("PARENT_SPAN_ID", events[0].parent_span_id);
 }
 
-TEST_F(ServiceTracingTest, ServiceRequestMintsRootSpan) {
-  // Verify service requests create root spans (no parent)
+TEST_F(ServiceTracingTest, ServiceTakeLeavesTraceEmptyForCorrelation) {
+  // ROB-406: the service take path must NO LONGER mint a fresh root trace.
+  // Previously rmw_take_request minted a new trace_id + empty parent on every
+  // take, guaranteeing every service request rendered as a separate root span.
+  // The new contract leaves trace_id AND parent_span_id EMPTY so the robot_agent
+  // CorrelationEngine can rewrite them to the client-send's trace (mirroring the
+  // subscribe path). The local thread context keeps the span_id (with an empty
+  // trace_id) so send_response can pair its RESPONSE to this REQUEST.
 
   EXPECT_TRUE(get_trace_context().is_empty());
 
-  // Simulate service receiving request
+  // Simulate the new service take behavior: span_id set, trace_id left empty.
   TraceContext new_context;
-  rmw_robotops::generate_trace_id(new_context.trace_id);
+  new_context.trace_id[0] = '\0';  // Empty → agent correlates
   rmw_robotops::generate_span_id(new_context.span_id);
-  new_context.parent_span_id[0] = '\0';  // Root span
+  new_context.parent_span_id[0] = '\0';
   set_trace_context(new_context);
 
   auto retrieved = get_trace_context();
-  EXPECT_FALSE(retrieved.is_empty());
-  EXPECT_EQ(0u, std::strlen(retrieved.parent_span_id));  // Root span
+  // span_id is present so send_response can pair with this request...
+  EXPECT_GT(std::strlen(retrieved.span_id), 0u);
+  // ...but trace_id is intentionally empty (the agent fills it in).
+  EXPECT_EQ(0u, std::strlen(retrieved.trace_id));
+  EXPECT_EQ(0u, std::strlen(retrieved.parent_span_id));
+}
+
+TEST_F(ServiceTracingTest, ServiceRequestCarriesConsumerDirectionAndHash) {
+  // ROB-406: a service-take SERVICE_REQUEST event is the CONSUMER end of the
+  // RPC and must carry DIRECTION_CONSUMER + a content hash + empty trace/parent
+  // so the agent correlates it to the client-send by content hash.
+  TraceEvent event;
+  event.event_type = robotops_msgs__msg__TraceEvent__EVENT_SERVICE_REQUEST;
+  event.trace_id[0] = '\0';
+  event.parent_span_id[0] = '\0';
+  rmw_robotops::generate_span_id(event.span_id);
+  event.correlation_method = robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+  event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_CONSUMER;
+  event.content_hash = 0xfeed'face'dead'beefULL;
+  snprintf(event.topic_or_service, sizeof(event.topic_or_service), "/test_service");
+
+  auto & queue = get_trace_event_queue();
+  ASSERT_TRUE(queue.try_push(event));
+
+  auto events = drain_queue();
+  ASSERT_EQ(1u, events.size());
+  EXPECT_EQ(0u, std::strlen(events[0].trace_id));        // empty → correlated
+  EXPECT_EQ(0u, std::strlen(events[0].parent_span_id));  // empty → correlated
+  EXPECT_EQ(
+    static_cast<uint8_t>(robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH),
+    events[0].correlation_method);
+  EXPECT_EQ(
+    static_cast<uint8_t>(robotops_msgs__msg__TraceEvent__DIRECTION_CONSUMER),
+    events[0].direction);
+  EXPECT_EQ(0xfeed'face'dead'beefULL, events[0].content_hash);
+}
+
+TEST_F(ServiceTracingTest, ClientRequestCarriesProducerDirection) {
+  // ROB-406: the client send_request SERVICE_REQUEST event is the PRODUCER end
+  // and seeds the correlation window in the agent.
+  TraceEvent event;
+  event.event_type = robotops_msgs__msg__TraceEvent__EVENT_SERVICE_REQUEST;
+  event.direction = robotops_msgs__msg__TraceEvent__DIRECTION_PRODUCER;
+  event.correlation_method = robotops_msgs__msg__TraceEvent__CORRELATION_FALLBACK_HASH;
+  event.content_hash = 0x0123'4567'89ab'cdefULL;
+
+  auto & queue = get_trace_event_queue();
+  ASSERT_TRUE(queue.try_push(event));
+
+  auto events = drain_queue();
+  ASSERT_EQ(1u, events.size());
+  EXPECT_EQ(
+    static_cast<uint8_t>(robotops_msgs__msg__TraceEvent__DIRECTION_PRODUCER),
+    events[0].direction);
+  EXPECT_EQ(0x0123'4567'89ab'cdefULL, events[0].content_hash);
 }
 
 TEST_F(ServiceTracingTest, ServiceResponseContinuesTrace) {


### PR DESCRIPTION
Promotes the version-bumped trace-fidelity changes to main for a prod release. Epic ROB-405.

https://claude.ai/code/session_01CTGD6b76YRbYHTiahBCHv4